### PR TITLE
Remove "Pi-hole v4.0 is currently under development"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-### <span style="color:red">Important: This documentation is for Pi-hole v4.0 which is currently under development</span>
-
 <p align="center">
 <a href="https://pi-hole.net"><img src="https://pi-hole.github.io/graphics/Vortex/Vortex_with_text.png" width="150" height="255" alt="Pi-hole"></a><br/>
 <b>Network-wide ad blocking via your own Linux hardware</b><br/>


### PR DESCRIPTION
Removes the red text as v4.0 has been officially released

![screenshot at 2018-08-07 23-38-08](https://user-images.githubusercontent.com/16748619/43804041-fe39a166-9a9a-11e8-95dc-80f9f175028c.png)
