### PR TITLE
Add redirect for /ftldns/regex/ to overview.html

### DIFF
--- a/docs/ftldns/regex/index.html
+++ b/docs/ftldns/regex/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=overview" />


### PR DESCRIPTION
The web interface links to `/ftldns/regex/` instead of `/ftldns/regex/overview`, and this change will make it easier to change structure without making bad links.