### PR TITLE
Fix build by locking dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iml
 /.idea
 .idea
+site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 install:
-- pip install mkdocs-material markdown-include
+- pip install -r requirements.txt
 script:
 - mkdocs build --verbose --clean
 deploy:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,27 +11,32 @@ theme:
 
 markdown_extensions:
 # Code highlighting in ``` ``` blocks
-  - codehilite(guess_lang=true)
+  - codehilite:
+      guess_lang: true
 # Table of Contents
-  - toc(permalink=true)
+  - toc:
+      permalink: true
 # block-styled side content
   - admonition
 # linkafies URL and email links without having to wrap them in Markdown syntax. Also, allows shortens repository issue, pull request, and commit links.
   - pymdownx.magiclink
 # Task lists (https://facelessuser.github.io/pymdown-extensions/extensions/tasklist/)
-  - pymdownx.tasklist(custom_checkbox=true)
+  - pymdownx.tasklist:
+      custom_checkbox: true
 # Highlight words with ==mark me==
   - pymdownx.mark
 # Adds support for deletion ~~Delete me~~ and subscript text~a\ subscript~
   - pymdownx.tilde
-# This extension is a convenience extension, and it currently provides no other additional features
+# This extension is a convenience extension which includes many pymdownx extensions
+# (https://facelessuser.github.io/pymdown-extensions/extensions/extra/)
   - pymdownx.extra
 # Adds syntax for defining footnotes in Markdown documents (https://python-markdown.github.io/extensions/footnotes/)
   - footnotes
 # Adds the ability to define abbreviations
   - abbr
 # Include files in other documents like {!some/dir/in/docs/filename.md!}
-  - markdown_include.include(base_path=docs)
+  - markdown_include.include:
+      base_path: docs
 pages:
 - 'Overview & Support': 'index.md'
 - 'Getting Started':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+backports-abc==0.5
+click==6.7
+futures==3.2.0
+Jinja2==2.10
+livereload==2.5.2
+Markdown==3.0
+markdown-include==0.5.1
+MarkupSafe==1.0
+mkdocs==1.0.4
+mkdocs-material==3.0.4
+Pygments==2.2.0
+pymdown-extensions==5.0
+PyYAML==3.13
+singledispatch==3.4.0.3
+six==1.11.0
+tornado==5.1.1


### PR DESCRIPTION
The dependency versions are now locked in requirements.txt. The mkdocs config had to be updated to use a different extension config style, as the old style seems to have been deprecated. The gitignore has been updated to ignore the build directory.

This should fix the build problem in #54 