### PR TITLE
Remove "for v4.0+"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: "Pi-hole documentation for v4.0+"
+site_name: "Pi-hole documentation"
 site_url: https://docs.pi-hole.net
 repo_url: "https://github.com/pi-hole/pi-hole/"
 edit_uri: ""


### PR DESCRIPTION
Remove "for v4.0+" part in the header as this is now the regular version of Pi-hole.