### PR TITLE
Port Caddy Configuration page from Wiki

### DIFF
--- a/docs/guides/caddy-configuration.md
+++ b/docs/guides/caddy-configuration.md
@@ -1,0 +1,63 @@
+# Caddy Webserver Frontend
+
+If you'd like to use Caddy as your main web server with PiHole, you'll need to make a few changes.
+
+## Modifying lighttpd configuration
+First, change the listen port in this file: 
+`/etc/lighttpd/lighttpd.conf:`
+
+```
+server.port                 = 1080
+```
+
+In this case I chose 1080 somewhat at random. Use whatever feels right to you.
+
+Next, restart the lighttpd server with either of these commands:
+- `sudo systemctl restart lighttpd` 
+- `sudo service lighttpd restart.`
+
+## Setting up your Caddyfile
+Now we need to set up a "virtual host" in our Caddyfile (default `/etc/caddy/Caddyfile`). There are many more options you can add, but at bare minimum you need to make a "default" host by binding `0.0.0.0:80`  which will accept requests for any host.
+```YAML
+blackhole:80, pi.hole:80, 0.0.0.0:80 {
+  root /var/www/html/pihole
+  log /var/log/caddy/blackhole.log
+
+  rewrite {
+    ext js
+    to index.js
+  }
+
+  proxy / localhost:1080 {
+    transparent
+  }
+}
+```
+In this case I've chosen to also add blackhole and pi.hole as valid names to open the admin page with.
+
+Finally, restart your Caddy server: 
+- `sudo service caddy restart`
+
+## Verifying your set up
+First, make sure that any other sites you're serving from caddy are still functioning. For example, if you have a block for `myawesomesite.com:80` in your Caddyfile, open up a browser to `http://myawesomesite.com` and verify it still loads.
+
+Next, verify you can load the admin page. Open up `http://pi.hole/admin` (or use the IP address of your server) and verify that you can access the admin page.
+
+Finally, verify that requests for ads are being black holed:
+```BASH
+$ curl -H "Host: badhost" pi.hole/
+<html>
+<head>
+<script>window.close();</script>
+</head>
+<body>
+</body>
+</html>
+```
+Replace the URL `pi.hole` with the IP address or alternate DNS name you're using if necessary.
+
+Lastly, ensure that requests for JavaScript files from advertisement domains are being served properly:
+```BASH
+curl -H "Host: badhost" pi.hole/malicious.js
+var x = "Pi-hole: A black hole for Internet advertisements."
+```

--- a/docs/guides/caddy-configuration.md
+++ b/docs/guides/caddy-configuration.md
@@ -1,6 +1,5 @@
-# Caddy Webserver Frontend
 
-If you'd like to use Caddy as your main web server with PiHole, you'll need to make a few changes.
+If you'd like to use Caddy as your main web server with Pi-hole, you'll need to make a few changes.
 
 ## Modifying lighttpd configuration
 First, change the listen port in this file: 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ pages:
 - 'Guides':
   - 'Pi-hole as All-Around DNS Solution': guides/unbound.md
   - 'Configuring DNS-Over-HTTPS on Pi-hole': guides/dns-over-https.md
+  - 'Configuring Caddy for Pi-Hole': guides/caddy-configuration.md
   - 'Pi-hole and OpenVPN Server':
     - 'Overview': 'guides/vpn/overview.md'
     - 'Installation': 'guides/vpn/installation.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,7 @@ pages:
 - 'Guides':
   - 'Pi-hole as All-Around DNS Solution': guides/unbound.md
   - 'Configuring DNS-Over-HTTPS on Pi-hole': guides/dns-over-https.md
-  - 'Configuring Caddy for Pi-Hole': guides/caddy-configuration.md
+  - 'Configuring Caddy for Pi-hole': guides/caddy-configuration.md
   - 'Pi-hole and OpenVPN Server':
     - 'Overview': 'guides/vpn/overview.md'
     - 'Installation': 'guides/vpn/installation.md'


### PR DESCRIPTION
Brought this page : https://github.com/pi-hole/pi-hole/wiki/Caddy-Webserver-Frontend over to be stored on the main docs site.

It's listed under the sites "Guides" section. Ran through the local mkdocs serv command to check compatibility.

![image](https://user-images.githubusercontent.com/7566941/46682377-47f52e80-cbe5-11e8-9317-1b33ac8d47b3.png)

Signed-off-by: Toakan <tdaykin@live.co.uk>