### PR TITLE
Add unsupported warning to nginx and caddy configs

### DIFF
--- a/docs/guides/caddy-configuration.md
+++ b/docs/guides/caddy-configuration.md
@@ -1,3 +1,4 @@
+**This is an unsupported configuration created by the community**
 
 If you'd like to use Caddy as your main web server with Pi-hole, you'll need to make a few changes.
 

--- a/docs/guides/nginx-configuration.md
+++ b/docs/guides/nginx-configuration.md
@@ -1,4 +1,5 @@
 ### Notes & Warnings
+- **This is an unsupported configuration created by the community**
 - If you're using php5, change all instances of `php7.0-fpm` to `php5-fpm` and change `/run/php/php7.0-fpm.sock` to `/var/run/php5-fpm.sock`
 
 ### Basic requirements


### PR DESCRIPTION
These guides were community created and maintained, and we are unable to fully support the configurations at this time.