### PR TITLE
Redirect /ftldns/regex/ to overview page using meta package.

### DIFF
--- a/docs/ftldns/regex/index.html
+++ b/docs/ftldns/regex/index.html
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="0; url=overview" />

--- a/docs/ftldns/regex/index.md
+++ b/docs/ftldns/regex/index.md
@@ -1,0 +1,7 @@
+---
+title: Redirect for /ftldns/regex/
+description: This url changed from page to subsection, must redirect from other sites to new page.
+last_updated: Mon Jan 14 11:47:02 2019 UTC
+redirect: /ftldns/regex/overview/
+---
+


### PR DESCRIPTION
https://github.com/pi-hole/docs/pull/76#pullrequestreview-191988229

Since a subsection can not have an associated page we have to use the folder directory and implicit index.md to index.html generation. The page /ftldns/regex/ will never show in the docs.pi-hole.net as a link, but there are other pages and sites that refer to this URL from when it was a page and not a subsection. 

This PR makes sure that calls to the old URL are redirected to the overview page.