### PR TITLE
add traefik without docker guide

### DIFF
--- a/docs/guides/traefik-configuration-nodocker.md
+++ b/docs/guides/traefik-configuration-nodocker.md
@@ -1,0 +1,73 @@
+### Notes & Warnings
+- **This is an unsupported configuration created by the community**
+- This describes on how to use traefik on a (possibly remote) machine to serve pi-hole via https and a different domain, not how to to this in docker (via docker-compose).
+
+### Basic requirements
+1. Have a traefik server running anywhere where it can access port 80 of the pihole server. Technically it can run in a docker container though. For LetsEncrypt to work traefik must be reachable on port 80 and 443 from the internet and have the domain.tld pointed at its external address.
+
+2. The following traefik config (traefik.toml)
+```
+debug = false
+checkNewVersion = true
+logLevel = "INFO"
+defaultEntryPoints = ["https","http"]
+
+[entryPoints]
+  [entryPoints.http]
+    address = ":80"
+    [entryPoints.http.redirect]
+      entryPoint = "https"
+  [entryPoints.https]
+    address = ":443"
+    [entryPoints.https.tls]
+      # Optional Security Settings
+[retry]
+
+[docker]
+  endpoint = "unix:///var/run/docker.sock"
+  domain = "domain.tld"
+  watch = true
+  exposedbydefault = false
+
+[acme]
+  email = "emailForLetsEncryptACME"
+  storage = "acme.json"
+  storageFile = "/etc/traefik/acme/acme.json"
+  entryPoint = "https"
+  OnHostRule = true
+  [acme.tlsChallenge]
+  [[acme.domains]]
+    main = "pihole.domain.tld"
+
+[file]
+  watch = true
+
+[backends]
+  [backends.pihole]
+    [backends.pihole.servers.server1]
+    url = "http://IP-Of-Pihole:80"
+
+[frontends]
+  [frontends.pihole]
+  backend = "pihole"
+  passHostHeader = true
+    [frontends.pihole.headers]
+    STSSeconds = 31536000
+    [frontends.pihole.routes.route1]
+    rule = "Host:pihole.domain.tld"
+```
+
+7. Edit your /etc/lighthttpd/external.conf to
+```
+$SERVER["socket"] == ":80" {
+  # Ensure the Pi-hole Block Page knows that this is not a blocked domain
+  setenv.add-environment = ("fqdn" => "true")
+
+
+  $HTTP["host"] =~ "^pi\.hole" {
+      url.redirect = ("^/(.*)" => "https://pihole.domain.tld/$1")
+  }
+}
+```
+
+8. Restart pi-holes lighthttpd and traefik, then you should be able to access your pihole via ```https://pihole.domain.tld/```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - 'Editing Whitelist and Blacklist': guides/whitelist-blacklist.md
   - 'Configuring NGINX for Pi-hole': guides/nginx-configuration.md
   - 'Configuring Caddy for Pi-hole': guides/caddy-configuration.md
+  - 'Configuring Traefik for Pi-hole (not in Docker)': guides/traefik-configuration-nodocker.md
   - 'Pi-hole and OpenVPN Server':
     - 'Overview': guides/vpn/overview.md
     - 'Installation': guides/vpn/installation.md


### PR DESCRIPTION
This is a guide on how to set up traefik as an external SSL Termination point for a domain to serve the pihole interface.