### PR TITLE
Add required packages for compiling FTL locally on Fedora

### DIFF
--- a/docs/ftldns/compile.md
+++ b/docs/ftldns/compile.md
@@ -3,11 +3,18 @@ We pre-compile *FTL*DNS for you to save you the trouble of compiling anything yo
 #### Installing the Required Software
 First, we'll install the basic software you'll need to compile from source, like the GCC compiler and other utilities.
 Install them by running the following command in a terminal:
-```
+###### Debian / Ubuntu / Raspbian
+```bash
 sudo apt install build-essential libgmp-dev m4
 ```
+###### Fedora
+```bash
+sudo dnf install gcc gmp-devel gmp-static m4
+```
 
-You'll also need to compile a recent version of `nettle` as *FTL*DNS uses `libnettle` for handling DNSSEC. Compile and install a recent version of `nettle` (we tested 3.4):
+---
+
+You'll also need to compile `nettle` as *FTL*DNS uses `libnettle` for handling DNSSEC. Compile and install a recent version of `nettle` (we tested 3.4):
 ```
 wget https://ftp.gnu.org/gnu/nettle/nettle-3.4.tar.gz
 tar -xvzf nettle-3.4.tar.gz


### PR DESCRIPTION
Add required packages for compiling locally on Fedora.
This will probably also work CentOS when using `yum` instead of `dnf`.

Preview:
![Screenshot from 2019-03-09 18-36-26](https://user-images.githubusercontent.com/16748619/54075061-b32d5480-429a-11e9-8874-5182a18ae719.png)
