### PR TITLE
Add `fastcgi_param FQDN true;` to nginx config

### DIFF
--- a/docs/guides/nginx-configuration.md
+++ b/docs/guides/nginx-configuration.md
@@ -34,6 +34,7 @@ server {
         location ~ \.php$ {
                 include snippets/fastcgi-php.conf;
                 fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+                fastcgi_param FQDN true;
                 auth_basic "Restricted"; #For Basic Auth
                 auth_basic_user_file /etc/nginx/.htpasswd;  #For Basic Auth
         }
@@ -77,7 +78,7 @@ server {
 
 -       If you want to use block page for any blocked domain subpage (aka Nginx 404), add this to Pi-hole server block in your Nginx configuration file:
 ```
-error_page 404 /pihole/index.php
+error_page 404 /pihole/index.php;
 ```
 -       When using nginx to serve Pi-hole, Let's Encrypt can be used to directly configure nginx. Make sure to use your hostname instead of _ in `server_name _;` line above.
 ```


### PR DESCRIPTION
This [adds the `$serverName` to the list of `$authorizedHosts`](https://github.com/pi-hole/pi-hole/blob/master/advanced/index.php#L26-L31) allowed to see the splash page, and should be equivalent to `setenv.add-environment = ("fqdn" => "true")` in lighttpd as [suggested in the Discourse FAQs](https://discourse.pi-hole.net/t/enabling-https-for-your-pi-hole-web-interface/5771). Without this, you could still visit `/admin` directly, but `/` (or any other page if `error_page 404 /pihole/index.php` is added as suggested below) would show [`[ERROR]: Unable to parse results from queryads.php: Unhandled error message ()`](https://github.com/pi-hole/pi-hole/issues/2195).