### PR TITLE
Fix the CI build by removing the futures package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 backports-abc==0.5
 Click==7.0
-futures==3.2.0
 Jinja2==2.10.1
 livereload==2.6.0
 Markdown==3.1


### PR DESCRIPTION
The CI now uses python 3.6 and errors out when trying to install futures. I tested, and it works fine on python 3.6 when the library is removed (previously it was on python 2).