### PR TITLE
Update unbound.md according to Unbond 1.9.0

### DIFF
--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -167,7 +167,7 @@ server:
     # https://github.com/wkumari/draft-kh-dnsop-7706bis/pull/8
     auth-zone:
         name: "."
-        zonefile: /db/root.zone
+        zonefile: /var/lib/unbound/root.zone
         master: 199.9.14.201        # b.root-servers.net
         master: 2001:500:200::b     # b.root-servers.net
         master: 192.33.4.12     # c.root-servers.net

--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -52,15 +52,9 @@ The first thing you need to do is to install the recursive DNS resolver:
 sudo apt install unbound
 ```
 
-**Important**: Download the current root hints file (the list of primary root servers which are serving the domain "." - the root domain). Update it roughly every six months. Note that this file changes infrequently.
-```
-wget -O root.hints https://www.internic.net/domain/named.root
-sudo mv root.hints /var/lib/unbound/
-```
-
 ### Configure `unbound`
 Highlights:
-- Listen only for queries from the local Pi-hole installation (on port 5353)
+- Listen only for queries from the local Pi-hole installation (on port 10053)
 - Listen for both UDP and TCP requests
 - Verify DNSSEC signatures, discarding BOGUS domains
 - Apply a few security and privacy tricks
@@ -68,11 +62,19 @@ Highlights:
  `/etc/unbound/unbound.conf.d/pi-hole.conf`:
 ```ini
 server:
+    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
+    num-threads: 1
+
     # If no logfile is specified, syslog is used
     # logfile: "/var/log/unbound/unbound.log"
     verbosity: 0
 
-    port: 5353
+    # Ensure Unbound is running on loopback interface
+    interface: 127.0.0.1@53
+
+    # Use an unassigned port
+    port: 10053
+
     do-ip4: yes
     do-udp: yes
     do-tcp: yes
@@ -80,54 +82,124 @@ server:
     # May be set to yes if you have IPv6 connectivity
     do-ip6: no
 
-    # Use this only when you downloaded the list of primary root servers!
-    root-hints: "/var/lib/unbound/root.hints"
+    # Access control to prevent access from non local network devices
+    # Block all
+    access-control: 0.0.0.0/0 refuse
+    access-control: ::0/0 refuse
+    # Allow lo0
+    access-control: 127.0.0.0/8 allow
+    access-control: ::1 allow
+    # Allow lan
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+    access-control: fd80:1fe9:fcee::/48 allow
 
-    # Trust glue only if it is within the servers authority
-    harden-glue: yes
+    # Prints one line per query to the log, making the server (significantly) slower
+    #log-queries: no
 
-    # Require DNSSEC data for trust-anchored zones, if such data is absent, the zone becomes BOGUS
-    harden-dnssec-stripped: yes
+    # Prevent banner disclosure
+    hide-identity: yes
+    hide-version: yes
+    # Refuse trustanchor.unbound queries
+    hide-trustanchor: yes
 
-    # Don't use Capitalization randomization as it known to cause DNSSEC issues sometimes
-    # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
-    use-caps-for-id: no
+    # The maximum dependency depth that Unbound will pursue in answering a query (reduced memory)
+    target-fetch-policy: "2 1 0 0 0 0"
 
-    # Reduce EDNS reassembly buffer size.
-    # Suggested by the unbound man page to reduce fragmentation reassembly problems
-    edns-buffer-size: 1472
+    harden-short-bufsize: yes
+    harden-large-queries: yes
 
-    # Perform prefetching of close to expired message cache entries
-    # This only applies to domains that have been frequently queried
-    prefetch: yes
+    # Use 0x20-encoded random bits in the query to foil spoof attempts
+    use-caps-for-id: yes
 
-    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
-    num-threads: 1
-
-    # Ensure kernel buffer is large enough to not lose messages in traffic spikes
-    so-rcvbuf: 1m
-
-    # Ensure privacy of local IP ranges
+    # DNSSEC bogus answers against DNS Rebinding
+    # RFC1918 private IP address space not allowed to be returned for public internet names
     private-address: 192.168.0.0/16
-    private-address: 169.254.0.0/16
     private-address: 172.16.0.0/12
     private-address: 10.0.0.0/8
+    private-address: 169.254.0.0/16
     private-address: fd00::/8
     private-address: fe80::/10
+    # Turning on 127.0.0.0/8 would hinder many spamblocklists as they use that
+    #private-address: 127.0.0.0/8
+    # Adding ::ffff:0:0/96 stops IPv4-mapped IPv6 addresses from bypassing the filter
+    private-address: ::ffff:0:0/96
+    # add 
+    private-address: 2001:470:b35c::/48
+
+    unwanted-reply-threshold: 10000000
+
+    do-not-query-localhost: no
+
+    # Affects buffer space
+    #prefetch: no
+
+    # UDP EDNS reassembly buffer advertised to peers. Default 4096.
+    # May need lowering on broken networks with fragmentation/MTU issues,
+    # particularly if validating DNSSEC.
+    #
+    #edns-buffer-size: 1480
+
+    # Use TCP for "forward-zone" requests. Useful if you are making
+    # DNS requests over an SSH port forwarding.
+    #
+    #tcp-upstream: yes
+
+    # DNS64 options, synthesizes AAAA records for hosts that don't have
+    # them. For use with NAT64 (PF "af-to").
+    #
+    #module-config: "dns64 validator iterator"
+    #dns64-prefix: 64:ff9b::/96 # well-known prefix (default)
+    #dns64-synthall: no
+
+    # Validation failure log level 2: query, reason, and server
+    val-log-level: 2
+
+    # Synthesise NXDOMAIN from nsec/nsec3 without hitting the authoritative
+    aggressive-nsec: yes
+
+    # Local copy of the full root zone, fallback to resolving from root servers
+    # "get off my lawn: if a lot of people were doing this it could considerably
+    # reduce the load on root nameservers and could increase resiliency in case of
+    # a dDOS attack on the root zone" --Florian Obser
+    # https://tools.ietf.org/html/draft-ietf-dnsop-7706bis-01
+    # https://github.com/wkumari/draft-kh-dnsop-7706bis/pull/8
+    auth-zone:
+        name: "."
+        zonefile: /db/root.zone
+        master: 199.9.14.201        # b.root-servers.net
+        master: 2001:500:200::b     # b.root-servers.net
+        master: 192.33.4.12     # c.root-servers.net
+        master: 2001:500:2::c       # c.root-servers.net
+        master: 199.7.91.13     # d.root-servers.net
+        master: 2001:500:2d::d      # d.root-servers.net
+        master: 192.5.5.241     # f.root-servers.net
+        master: 2001:500:2f::f      # f.root-servers.net
+        master: 192.112.36.4        # g.root-servers.net
+        master: 2001:500:12::d0d    # g.root-servers.net
+        master: 193.0.14.129        # k.root-servers.net
+        master: 2001:7fd::1     # k.root-servers.net
+        master: 192.0.32.132        # xfr.lax.dns.icann.org
+        master: 2620:0:2d0:202::132 # xfr.lax.dns.icann.org
+        master: 192.0.47.132        # xfr.cjr.dns.icann.org
+        master: 2620:0:2830:202::132    # xfr.cjr.dns.icann.org
+        fallback-enabled: yes
+        for-downstream: no
 ```
 
 Start your local recursive server and test that it's operational:
 ```
 sudo service unbound start
-dig pi-hole.net @127.0.0.1 -p 5353
+dig pi-hole.net @127.0.0.1 -p 10053
 ```
 The first query may be quite slow, but subsequent queries, also to other domains under the same TLD, should be fairly quick.
 
 ### Test validation
 You can test DNSSEC validation using
 ```
-dig sigfail.verteiltesysteme.net @127.0.0.1 -p 5353
-dig sigok.verteiltesysteme.net @127.0.0.1 -p 5353
+dig sigfail.verteiltesysteme.net @127.0.0.1 -p 10053
+dig sigok.verteiltesysteme.net @127.0.0.1 -p 10053
 ```
 The first command should give a status report of `SERVFAIL` and no IP address. The second should give `NOERROR` plus an IP address.
 

--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -62,17 +62,16 @@ Highlights:
  `/etc/unbound/unbound.conf.d/pi-hole.conf`:
 ```ini
 server:
-    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
+    # One thread should be sufficient, can be increased on beefy machines.
+    # In reality for most users running on small networks or on a single machine it
+    # should be unnecessary to seek performance enhancement by increasing num-threads above 1.
     num-threads: 1
 
     # If no logfile is specified, syslog is used
     # logfile: "/var/log/unbound/unbound.log"
     verbosity: 0
 
-    # Ensure Unbound is running on loopback interface
-    interface: 127.0.0.1@53
-
-    # Use an unassigned port
+    # Use an unassigned port, port 5353 for example is used by Avahi / Multicast DNS
     port: 10053
 
     do-ip4: yes
@@ -89,11 +88,6 @@ server:
     # Allow lo0
     access-control: 127.0.0.0/8 allow
     access-control: ::1 allow
-    # Allow lan
-    access-control: 192.168.0.0/16 allow
-    access-control: 172.16.0.0/12 allow
-    access-control: 10.0.0.0/8 allow
-    access-control: fd80:1fe9:fcee::/48 allow
 
     # Prints one line per query to the log, making the server (significantly) slower
     #log-queries: no
@@ -106,11 +100,15 @@ server:
 
     # The maximum dependency depth that Unbound will pursue in answering a query (reduced memory)
     target-fetch-policy: "2 1 0 0 0 0"
-
+    
+    # Very small EDNS buffer sizes from queries are ignored
     harden-short-bufsize: yes
+    
+    # Very large queries are ignored
     harden-large-queries: yes
 
     # Use 0x20-encoded random bits in the query to foil spoof attempts
+    # See "https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378" for further details
     use-caps-for-id: yes
 
     # DNSSEC bogus answers against DNS Rebinding
@@ -121,25 +119,24 @@ server:
     private-address: 169.254.0.0/16
     private-address: fd00::/8
     private-address: fe80::/10
-    # Turning on 127.0.0.0/8 would hinder many spamblocklists as they use that
-    #private-address: 127.0.0.0/8
     # Adding ::ffff:0:0/96 stops IPv4-mapped IPv6 addresses from bypassing the filter
     private-address: ::ffff:0:0/96
-    # add 
-    private-address: 2001:470:b35c::/48
 
+    # Prevents against DNS poisoning, when the threshold is reached, rrset and 
+    # message caches are cleared and a warning is printed
     unwanted-reply-threshold: 10000000
 
+    # Localhost can be used for queries
     do-not-query-localhost: no
 
-    # Affects buffer space
+    # Affects buffer space. Turning it on gives about 10 percent more traffic and
+    # load on the machine, but popular items do not expire from the cache.
     #prefetch: no
 
     # UDP EDNS reassembly buffer advertised to peers. Default 4096.
     # May need lowering on broken networks with fragmentation/MTU issues,
     # particularly if validating DNSSEC.
-    #
-    #edns-buffer-size: 1480
+    #edns-buffer-size: 1472
 
     # Use TCP for "forward-zone" requests. Useful if you are making
     # DNS requests over an SSH port forwarding.


### PR DESCRIPTION
Hi,

Since Raspbian and Debian are now on the Buster branch, they come with Unbound 1.9.0, I've updated the configs accordingly, the configs are heavily inspired by [Vedetta OpenBSD Router Boilerplate](https://github.com/vedetta-com/vedetta/blob/master/src/var/unbound/etc/unbound.conf). All credits to them! And special thanks to @horia!!!

Changes highlights:
- Removed the steps to download the root.hints file, since they aren't necessary.
- Removed the redundant default "on" options
- Changed the bind port from 5353 to 10053 (unassigned), since Multicast DNS devices use 5353.
- New hardening options
- RFC 7706 for reduced latency, improved privacy and increased resiliency in case of DDoS attacks on the root zones.

I've tested the config on my RPi with no problems.