### PR TITLE
Remove FamilyShield DNS

### DIFF
--- a/docs/guides/upstream-dns-providers.md
+++ b/docs/guides/upstream-dns-providers.md
@@ -6,7 +6,6 @@ Level3
 Comodo
 DNS.WATCH
 Quad9
-FamilyShield DNS
 CloudFlare DNS
 Custom
 ```


### PR DESCRIPTION
It has not been an option in the installer for some time.