### PR TITLE
Fix broken links

### DIFF
--- a/docs/core/pihole-command.md
+++ b/docs/core/pihole-command.md
@@ -130,7 +130,7 @@ Chronometer is a console dashboard of real-time stats, which can be displayed vi
 | | |
  -------------- | --------------
 Help Command    | N/A
-Script Location | [`/opt/pihole/gravity.sh`](https://github.com/pi-hole/pi-hole/blob/master/advanced/Scripts/gravity.sh)
+Script Location | [`/opt/pihole/gravity.sh`](https://github.com/pi-hole/pi-hole/blob/master/gravity.sh)
 Example Usage   | [`pihole -g`](https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#gravity)
 
 Gravity is one of the most important scripts of Pi-hole. Its main purpose is to retrieve blocklists, and then consolidate them into one unique list for the built-in DNS server to use, but it also serves to complete the process of manual whitelisting, blacklisting and wildcard update. It is run automatically each week, but it can be invoked manually at any time.

--- a/docs/guides/tor/performance-issues.md
+++ b/docs/guides/tor/performance-issues.md
@@ -2,7 +2,7 @@
 
 You're constantly using new DNS Servers that are located all over the world, so it might happen that sometimes hostname resolving is slow or might not work at all for certain domains. In this cases you have to wait some minutes until you switch to another Tor circuit or configure Tor to accept control connections and send a command that tells Tor to [switch circuits immediately](https://superuser.com/a/139018).   
 
-You could set `ExitNodes` in your torrc to a specific set of Exit nodes that are reliable for you or use only Exit nodes in a [specific country](http://www.b3rn3d.com/blog/2014/03/05/tor-country-codes/) (on Debian derivatives you need to have the `tor-geoipdb` package installed for that to work) and thus avoid problems with DNS lookups to some extend. 
+You could set `ExitNodes` in your torrc to a specific set of Exit nodes that are reliable for you or use only Exit nodes in a [specific country](https://b3rn3d.herokuapp.com/blog/2014/03/05/tor-country-codes/) (on Debian derivatives you need to have the `tor-geoipdb` package installed for that to work) and thus avoid problems with DNS lookups to some extend. 
 
 Keep in mind that this approach increases the correlation attack vulnerability if you only have a small amount of `ExitNodes` set or your selected country/s has/have few Exit nodes. If your goal is only to slightly increase security and maintain performance and reliability, this approach might be for you. It is not recommended.
 

--- a/docs/guides/vpn/firewall.md
+++ b/docs/guides/vpn/firewall.md
@@ -66,8 +66,6 @@ iptables -A INPUT -p udp --dport 443 -j REJECT --reject-with icmp-port-unreachab
 
 Depending on the systems you have connecting, you may benefit from appending `--reject-with tcp-reset` to the command above.  If you still get slow load times of HTTPS assets, the above may help.
 
-If you want to test how your Pi-hole behaves with blocking HTTP vs. HTTPS assets, use [this page](https://pi-hole.net/pages-to-test-ad-blocking-performance/#https-test).
-
 ##### IPv6 `iptables`
 
 If your server is reachable via IPv6, you'll need to run the same commands but using `ip6tables`:


### PR DESCRIPTION
Fixes   #169 

3 broken links:

- **docs/core/pihole-command.md** has a link "/opt/pihole/gravity.sh" which points to the wrong directory.
- **docs/guides/tor/performance-issues.md** has a link "specific country" which points to a blog that has been moved to a new page.

- **docs/guides/vpn/firewall.md** has a link "this page" which points to a page that no longer exists (per [this thread](https://www.reddit.com/r/pihole/comments/b0o0rv/what_happened_to_the_page_on_piholes_website/)). 
  - I figured that since this test page no longer exists, the entire sentence pointing to it can be removed.