### PR TITLE
Update restart target to match OpenVPNv2.4 service

### DIFF
--- a/docs/guides/vpn/setup-openvpn-server.md
+++ b/docs/guides/vpn/setup-openvpn-server.md
@@ -38,8 +38,8 @@ verb 3
 
 Depending on your operating system, one of these commands should work to restart the service.
 ```
-systemctl restart openvpn
-service openvpn restart
+systemctl restart openvpn-server@server
+service openvpn-server@server restart
 ```
 
 ## Create a client config file (`.ovpn`)


### PR DESCRIPTION
# What changed?

In February 2019, OpenVPNv2.4 changed the structure they use for `systemd` services. Instead of using the service named `openvpn.service`, it's now templated. For the purposes of the VPN setup guide, the correct service to target is `openvpn-server@server.service`.

The road warrior install script was ported to target this new service in June 2019. [See here for the commit where this was changed.](https://github.com/Nyr/openvpn-install/commit/a46a23d84a4b007dc8f6e964219331f876a21602#diff-cda9722285f1718b319bb88e134e9efeR354)

# Why is this important?

The outdated reload snippet in the guide will **not** properly load in any edits made to `server.conf`. This causes a confusing bug that allows the use of the VPN under normal circumstances, but seemingly with outdated configuration. The user who's most likely affected is one who is running the VPN locally, and edits in the DHCP DNS override at a later point in time but cannot get the changes to propagate.

I've tested this with my local pihole / OpenVPN setup and have it working.

As a side note, I might suggest that this guide be rewritten to suggest [PiVPN](http://www.pivpn.io/) as the installer for OpenVPN instead of the road warrior script - it's much more user friendly, the CLI for it is better, and has better feature support, such as generating encrypted `.ovpn` files.