### PR TITLE
Update dns-over-https.md

### DIFF
--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -200,6 +200,8 @@ sudo systemctl status cloudflared
 
 ```bash
 sudo systemctl stop cloudflared
+sudo systemctl disable cloudflared
+sudo systemctl daemon-reload
 sudo deluser cloudflared
 sudo rm /etc/default/cloudflared
 sudo rm /etc/systemd/system/cloudflared.service

--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -177,7 +177,7 @@ Finally, configure Pi-hole to use the local `cloudflared` service as the upstrea
 
 ### Updating `cloudflared`
 
-You may want to update `cloudflared` from time to time. To do so repeat the steps shown in the beginning after stopping the service and restarting it.
+#### Manual way
 
 ```bash
 # stop the service
@@ -190,6 +190,13 @@ sudo chmod +x /usr/local/bin/cloudflared
 sudo systemctl start cloudflared
 # verify the service is working fine
 sudo systemctl status cloudflared
+```
+
+#### Automatic way
+
+```bash
+sudo cloudflared update
+sudo systemctl restart cloudflared
 ```
 
 ### Uninstalling `cloudflared`


### PR DESCRIPTION
Recent versions of cloudflared include a service install/uninstall command which saves some manual steps

I only tested this on Raspbian buster and not for a long time, but it does seem to work. Let me know what you think

* [x] Add uninstall instructions
* [x] Add update instructions
* [x]  Revisit uninstall commands; maybe add `sudo systemctl disable cloudflared` and `sudo systemctl daemon-reload`

Preview: <https://deploy-preview-186--pihole-docs.netlify.com/guides/dns-over-https/>