### PR TITLE
Add instuctions for updating cloudflared binary.

### DIFF
--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -60,9 +60,11 @@ sudo useradd -s /usr/sbin/nologin -r -M cloudflared
 Proceed to create a configuration file for `cloudflared` by copying the following in to `/etc/default/cloudflared`. This file contains the command-line options that get passed to cloudflared on startup:
 
 ```bash
-# Commandline args for cloudflared
+# Commandline args for cloudflared, using Cloudflare DNS
 CLOUDFLARED_OPTS=--port 5053 --upstream https://1.1.1.1/dns-query --upstream https://1.0.0.1/dns-query
 ```
+
+**Note:** The `cloudflared` binary will work with other DoH providers (for example, you could use https://8.8.8.8/dns-query for Google DNS).
 
 Update the permissions for the configuration file and `cloudflared` binary to allow access for the cloudflared user:
 
@@ -226,16 +228,16 @@ After the above, don't forget to change the DNS back to something else in Pi-hol
 
 ### Updating Cloudflared
 
-The `cloudflared` tool will not receive updates through the package manager, but it can be instrcted to update itself. 
-
-To do this, create the following script, and place it in `/etc/cron.weekly/cloudflared-updater.sh`:
+The `cloudflared` tool will not receive updates through the package manager, however it can be updated
+manually by running these commands:
 
 ```bash
 cloudflared update
 systemctl restart cloudflared
 ```
 
-Adjust permissions:
+If you want to have the system update `cloudflared` automatically, simply place the update commands in the
+file `/etc/cron.weekly/cloudflared-updater.sh`, and adjust permissions:
 
 ```bash
 sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh

--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -13,6 +13,8 @@ Along with releasing their DNS service [1.1.1.1](https://blog.cloudflare.com/ann
 
 In the following sections, we will be covering how to install and configure this tool on `Pi-hole`.
 
+**Note:** The `cloudflared` binary will work with other DoH providers (for example, you could use `https://8.8.8.8/dns-query` for Google's DNS-Over-HTTPS service).
+
 ### Installing `cloudflared`
 
 The installation is fairly straightforward, however, be aware of what architecture you are installing on (`amd64` or `arm`).
@@ -63,8 +65,6 @@ Proceed to create a configuration file for `cloudflared` by copying the followin
 # Commandline args for cloudflared, using Cloudflare DNS
 CLOUDFLARED_OPTS=--port 5053 --upstream https://1.1.1.1/dns-query --upstream https://1.0.0.1/dns-query
 ```
-
-**Note:** The `cloudflared` binary will work with other DoH providers (for example, you could use `https://8.8.8.8/dns-query` for Google DNS).
 
 Update the permissions for the configuration file and `cloudflared` binary to allow access for the cloudflared user:
 
@@ -179,7 +179,13 @@ Finally, configure Pi-hole to use the local `cloudflared` service as the upstrea
 
 ### Updating `cloudflared`
 
-#### Manual way
+The `cloudflared` tool will not receive updates through the package manager. However, you should keep the program update to date. You can either do this manually, or via a cron script.
+
+The procedure for updating depends on how you configured the `cloudflared` binary.
+
+#### If you configured cloudflared with your own service files
+
+If you configured `cloudflared` manually (by writing a systemd unit yourself), to update the binary you'll simply redownload the binary from the same link, and repeat the install procedure.
 
 ```bash
 wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.tgz
@@ -192,12 +198,26 @@ cloudflared -v
 sudo systemctl status cloudflared
 ```
 
-#### Automatic way
+#### If you configued cloudflared via `service install`
+
+If you configured `cloudflared` using their `service install` command, then you can use the built in update command.
 
 ```bash
 sudo cloudflared update
 sudo systemctl restart cloudflared
 ```
+
+#### Automating Cloudflared Updates
+
+If you want to have the system update `cloudflared` automatically, simply place the update commands for your configuration method in the
+file `/etc/cron.weekly/cloudflared-updater.sh`, and adjust permissions:
+
+```bash
+sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh
+sudo chown root:root /etc/cron.weekly/cloudflared-updater.sh
+```
+
+The system will now attempt to update the cloudflared binary automatically, once per week.
 
 ### Uninstalling `cloudflared`
 
@@ -225,23 +245,3 @@ sudo systemctl daemon-reload
 After the above, don't forget to change the DNS back to something else in Pi-hole's DNS settings!
 
 [^guide]: Based on [this guide by Ben Dews | bendews.com](https://bendews.com/posts/implement-dns-over-https/)
-
-### Updating Cloudflared
-
-The `cloudflared` tool will not receive updates through the package manager, however it can be updated
-manually by running these commands:
-
-```bash
-sudo cloudflared update
-sudo systemctl restart cloudflared
-```
-
-If you want to have the system update `cloudflared` automatically, simply place the update commands in the
-file `/etc/cron.weekly/cloudflared-updater.sh`, and adjust permissions:
-
-```bash
-sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh
-sudo chown root:root /etc/cron.weekly/cloudflared-updater.sh
-```
-
-The system will now attempt to update the cloudflared binary automatically, once per week.

--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -64,7 +64,7 @@ Proceed to create a configuration file for `cloudflared` by copying the followin
 CLOUDFLARED_OPTS=--port 5053 --upstream https://1.1.1.1/dns-query --upstream https://1.0.0.1/dns-query
 ```
 
-**Note:** The `cloudflared` binary will work with other DoH providers (for example, you could use https://8.8.8.8/dns-query for Google DNS).
+**Note:** The `cloudflared` binary will work with other DoH providers (for example, you could use `https://8.8.8.8/dns-query` for Google DNS).
 
 Update the permissions for the configuration file and `cloudflared` binary to allow access for the cloudflared user:
 
@@ -244,4 +244,4 @@ sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh
 sudo chown root:root /etc/cron.weekly/cloudflared-updater.sh
 ```
 
-The system will now attempt to update the cloudflared binary automatically, once per week. 
+The system will now attempt to update the cloudflared binary automatically, once per week.

--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -232,8 +232,8 @@ The `cloudflared` tool will not receive updates through the package manager, how
 manually by running these commands:
 
 ```bash
-cloudflared update
-systemctl restart cloudflared
+sudo cloudflared update
+sudo systemctl restart cloudflared
 ```
 
 If you want to have the system update `cloudflared` automatically, simply place the update commands in the

--- a/docs/guides/dns-over-https.md
+++ b/docs/guides/dns-over-https.md
@@ -223,3 +223,23 @@ sudo systemctl daemon-reload
 After the above, don't forget to change the DNS back to something else in Pi-hole's DNS settings!
 
 [^guide]: Based on [this guide by Ben Dews | bendews.com](https://bendews.com/posts/implement-dns-over-https/)
+
+### Updating Cloudflared
+
+The `cloudflared` tool will not receive updates through the package manager, but it can be instrcted to update itself. 
+
+To do this, create the following script, and place it in `/etc/cron.weekly/cloudflared-updater.sh`:
+
+```bash
+cloudflared update
+systemctl restart cloudflared
+```
+
+Adjust permissions:
+
+```bash
+sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh
+sudo chown root:root /etc/cron.weekly/cloudflared-updater.sh
+```
+
+The system will now attempt to update the cloudflared binary automatically, once per week. 


### PR DESCRIPTION
Adds a section to the DNS-Over-HTTPS guide with instructions for how to ensure the cloudflared daemon is kept up-to-date.

This adds update instructions for cloudflared, which handles one part of issue #175 