### PR TITLE
docs/index.md: switch to the SVG image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-<p style="text-align: center;">
-    <a href="https://pi-hole.net">
-        <img src="https://pi-hole.github.io/graphics/Vortex/Vortex_with_text.png" width="150" height="255" alt="Pi-hole">
+<p align="center">
+    <a href="https://pi-hole.net/">
+        <img src="https://pi-hole.github.io/graphics/Vortex/Vortex_with_Wordmark.svg" width="150" height="260" alt="Pi-hole">
     </a>
     <br>
     <strong>Network-wide ad blocking via your own Linux hardware</strong>
-    <br>
 </p>
 
 The Pi-hole[®](https://pi-hole.net/trademark-rules-and-brand-guidelines/) is a [DNS sinkhole](https://en.wikipedia.org/wiki/DNS_Sinkhole) that protects your devices from unwanted content, without installing any client-side software.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,11 @@ last_updated: Thur May 02 01:00:00 2019 UTC
 ---
 
 <p style="text-align: center;">
-    <a href="https://pi-hole.net">
-        <img src="https://pi-hole.github.io/graphics/Vortex/Vortex_with_text.png" width="150" height="255" alt="Pi-hole">
+    <a href="https://pi-hole.net/">
+        <img src="https://pi-hole.github.io/graphics/Vortex/Vortex_with_Wordmark.svg" width="150" height="260" alt="Pi-hole">
     </a>
     <br>
     <strong>Network-wide ad blocking via your own Linux hardware</strong>
-    <br>
 </p>
 
 The Pi-hole[®](https://pi-hole.net/trademark-rules-and-brand-guidelines/) is a [DNS sinkhole](https://en.wikipedia.org/wiki/DNS_Sinkhole) that protects your devices from unwanted content, without installing any client-side software.


### PR DESCRIPTION
Note that since GitHub strips `style` etc for security reasons, we need to use the obsolete `align` attribute in README.md.
