### PR TITLE
Revert "Add revision date to pages."

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,3 @@ extra:
 
 extra_css:
   - extra.css
-
-plugins:
-  - search
-  - git-revision-date-localized

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ MarkupSafe==1.1.1
 mkdocs==1.0.4
 mkdocs-material==4.6.2
 mkdocs-minify-plugin==0.2.1
-mkdocs-git-revision-date-localized-plugin==0.4.5
 Pygments==2.5.2
 pymdown-extensions==6.3
 PyYAML==5.3


### PR DESCRIPTION
Reverts pi-hole/docs#244

Plugin only added date of last build and not date of last modification to the page.