### PR TITLE
Update mkdocs-material to v5.1.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ copyright: 'Copyright &copy; 2019 Pi-hole LLC'
 remote_branch: gh-pages
 theme:
   name: 'material'
+#  icon:
+#    repo: fontawesome/brands/github-alt
   favicon: 'images/favicon.ico'
   logo: 'images/logo.svg'
   language: 'en'
@@ -111,9 +113,9 @@ nav:
 
 extra:
   social:
-    - type: globe
+    - icon: fontawesome/solid/globe-americas
       link: https://pi-hole.net/
-    - type: github-alt
+    - icon: fontawesome/brands/github
       link: https://github.com/pi-hole
 
 extra_css:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 markdown-include==0.5.1
 mkdocs==1.1
 mkdocs-git-revision-date-localized-plugin==0.5.0
-mkdocs-material==4.6.3
+mkdocs-material==5.1.0


### PR DESCRIPTION
WIP until v5.0.0 final is out and also we agree on some of the new changes

Not sure if we should keep the default theme icon for the repo; I kept what v4 was using.

Also, I'm not 100% sure if we should enable instant loading; I'll need to test it a little bit more

Preview: <https://deploy-preview-275--pihole-docs.netlify.com/>