### PR TITLE
Add information on 1.1.1.1 for Families

### DIFF
--- a/docs/guides/upstream-dns-providers.md
+++ b/docs/guides/upstream-dns-providers.md
@@ -105,7 +105,7 @@ Malware and Adult Content
 - 2606:4700:4700::1113 (IPv6)
 - 2606:4700:4700::1003 (IPv6)
 
-[More info on 1.1.1.1 for Families(https://blog.cloudflare.com/introducing-1-1-1-1-for-families/)]
+[More info on 1.1.1.1 for Families](https://blog.cloudflare.com/introducing-1-1-1-1-for-families/)
 
 ### Custom
 

--- a/docs/guides/upstream-dns-providers.md
+++ b/docs/guides/upstream-dns-providers.md
@@ -94,12 +94,14 @@ CloudFlare will never log your IP address (the way other companies identify you)
 Cloudflare also provides 1.1.1.1 for Families, a set of resolvers that can block malware only, or malware and adult content.
 
 Malware Blocking Only
+
 - 1.1.1.2
 - 1.0.0.2
 - 2606:4700:4700::1112 (IPv6)
 - 2606:4700:4700::1002 (IPv6)
 
 Malware and Adult Content
+
 - 1.1.1.3
 - 1.0.0.3
 - 2606:4700:4700::1113 (IPv6)

--- a/docs/guides/upstream-dns-providers.md
+++ b/docs/guides/upstream-dns-providers.md
@@ -91,6 +91,22 @@ CloudFlare will never log your IP address (the way other companies identify you)
 
 [More information on Cloudflare DNS](https://cloudflare-dns.com/dns/#explanation)
 
+Cloudflare also provides 1.1.1.1 for Families, a set of resolvers that can block malware only, or malware and adult content.
+
+Malware Blocking Only
+- 1.1.1.2
+- 1.0.0.2
+- 2606:4700:4700::1112 (IPv6)
+- 2606:4700:4700::1002 (IPv6)
+
+Malware and Adult Content
+- 1.1.1.3
+- 1.0.0.3
+- 2606:4700:4700::1113 (IPv6)
+- 2606:4700:4700::1003 (IPv6)
+
+[More info on 1.1.1.1 for Families(https://blog.cloudflare.com/introducing-1-1-1-1-for-families/)]
+
 ### Custom
 
 With custom, you'll choose your favorite DNS provider. If you care about Internet independence and privacy, we suggest having a look at the [OpenNIC DNS Project](https://servers.opennic.org/).


### PR DESCRIPTION
Added info on 1.1.1.1 for Families, including a blog link to explain the service.

Initially using the blog post link, but more info on 1.1.1.1 for Families might make better sense to point to here to make Cloudflare links more uniform: https://cloudflare-dns.com/family/