### PR TITLE
General tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When working on this repo, it is advised that you review your changes locally be
 
 Please make sure you fork the repo and change the clone URL in the example below for your fork:
 
-- Linux Mint / Ubuntu 18.04 LTS / 19.10:
+- Linux Mint / Ubuntu 18.04 LTS / 19.10 / 20.04 LTS:
     - Preparations (only required once):
 
     ```bash

--- a/docs/ftldns/compile.md
+++ b/docs/ftldns/compile.md
@@ -19,12 +19,12 @@ sudo dnf install gcc gmp-devel gmp-static m4
 
 ---
 
-You'll also need to compile `nettle` as *FTL*DNS uses `libnettle` for handling DNSSEC. Compile and install a recent version of `nettle` (we recommend 3.5):
+You'll also need to compile `nettle` as *FTL*DNS uses `libnettle` for handling DNSSEC. Compile and install a recent version of `nettle` (we tested and recommend 3.6):
 
 ```bash
-wget https://ftp.gnu.org/gnu/nettle/nettle-3.5.tar.gz
-tar -xvzf nettle-3.5.tar.gz
-cd nettle-3.5
+wget https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz
+tar -xvzf nettle-3.6.tar.gz
+cd nettle-3.6
 ./configure
 make
 sudo make install
@@ -44,7 +44,7 @@ If you want to build another branch and not `master`, use checkout to get to thi
 *FTL*DNS can now be compiled and installed:
 
 ```bash
-make -j 4
+make -j $(nproc)
 sudo make install
 ```
 

--- a/docs/ftldns/dns-resolver.md
+++ b/docs/ftldns/dns-resolver.md
@@ -16,13 +16,13 @@ We place hooks in a lot of places in the resolver that branch out into `FTL` cod
 
 #### Remove limit on maximum cache size
 
-Users can configure the size of the resolver's name cache. The default is 150 names. Setting the cache size to zero disables caching. We think users should be allowed to set the cache size to any value they find appropriate. However, `dnsmasq`'s source code contains a condition that limits the maximum size of the cache to 10,000 names. We removed this hard-coded upper limit in [option.c](https://github.com/pi-hole/FTL/commit/ea3309e7b1991f50d40555b9a18f39894c237b29#diff-733116077302620357dcd8252f41449dR2582R258) and submitted a patch to remove this hard-coded limit in the upstream version of `dnsmasq`.
+Users can configure the size of the resolver's name cache. The default is 150 names. Setting the cache size to zero disables caching. We think users should be allowed to set the cache size to any value they find appropriate. However, `dnsmasq`'s source code contains a condition that limits the maximum size of the cache to 10,000 names. We removed this hard-coded upper limit in and submitted a patch to remove this hard-coded limit in the upstream version of `dnsmasq`. It was accepted for `dnsmasq v2.81`.
 
 #### Improve detection algorithm for determining the "best" forward destination
 
 The DNS forward destination determination algorithm in *FTL*DNS's is modified to be much less restrictive than the original algorithm in `dnsmasq`. We keep using the fastest responding server now for 1000 queries or 10 minutes (whatever happens earlier) instead of 50 queries or 10 seconds (default values in `dnsmasq`).
 We keep the exceptions, i.e., we try all possible forward destinations if `SERVFAIL` or `REFUSED` is received or if a timeout occurs.
 Overall, this change has proven to greatly reduce the number of actually performed queries in typical Pi-hole environments. It may even be understood as being preferential in terms of privacy (as we send queries much less often to all servers).
-This has been implemented in commit [d1c163e](https://github.com/pi-hole/FTL/commit/d1c163e499a5cd9f311610e9da1e9365bbf81e89) on the `FTLDNS` branch.
+This has been implemented in commit [d1c163e](https://github.com/pi-hole/FTL/commit/d1c163e499a5cd9f311610e9da1e9365bbf81e89).
 
 {!abbreviations.md!}

--- a/docs/ftldns/in-depth.md
+++ b/docs/ftldns/in-depth.md
@@ -23,10 +23,6 @@ Command-line arguments can be arbitrarily combined, e.g. `pihole-FTL debug test`
 - `/var/run/pihole-FTL.port` file containing port on which `FTL` is listening
 - `/var/run/pihole/FTL.sock` Unix socket
 
-## Domain lists format
-
-Since Pi-hole v4.0, we use a simpler domain list format for the two important blocklist files `gravity.list` and `black.list`. In contrast to the traditional HOSTS format (which caused a lot of overhead), the domain list format is the minimal possible solution for saving memory while still using plain text lists for your convenience. When *FTL*DNS imports these two files, they are walked by our improved list parser speeding up the loading of blocklists significantly. Regardless of which blocking mode (`IP` or `NXDOMAIN`) is selected, *FTL*DNS will always load the lists into its internal hashed cache to be able to determine the blocking status within a few milliseconds, even when you're using huge blocking lists on low-end devices. With everything we do, we design *FTL*DNS for maximum efficiency also on low-performance devices.
-
 ## Linux capabilities
 
 Capabilities (POSIX 1003.1e, [capabilities(7)](http://man7.org/linux/man-pages/man7/capabilities.7.html)) provide fine-grained control over superuser permissions, allowing the use of the `root` user to be avoided.

--- a/docs/ftldns/privacylevels.md
+++ b/docs/ftldns/privacylevels.md
@@ -39,11 +39,4 @@ This setting disables
 - Query Log
 - Long-term database logging
 
-### Level 4 - disabled statistics (v4.1+)
-
-Disables all statistics processing. Even the query counters will not be available.
-Additionally, you can disable logging to the file `/var/log/pihole.log` using `sudo pihole logging off`.
-
-Note that - due to the disabled query processing - regex blocking is **not** available on level 4.
-
 {!abbreviations.md!}


### PR DESCRIPTION
- Update `libnettle` version (v3.6 released 2020-04-29)
    > Nettle is a cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space. 
- Remove outdated section about `gravity.list`
- Remove privacy level 4 as blocking does not work in this mode (we will remove it for v5.1). No harm to remove the documentation already now. Disabling any processing effectively disables blocking which is counterproductive.
- Removal of hard-coded cache size limit has been removed upstream in dnsmasq v2.81, so remove this comment