### PR TITLE
Rename Raspbian to Raspberry Pi OS in supported OS

### DIFF
--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -24,7 +24,7 @@ The following operating systems are **officially** supported:
 
 | Distribution | Release          | Architecture        |
 | ------------ | ---------------- | ------------------- |
-| Raspbian     | Stretch / Buster | ARM                 |
+| Raspberry Pi OS  (Raspbian)     | Stretch / Buster | ARM                 |
 | Ubuntu       | 16.x / 18.x / 20.x      | ARM / x86_64        |
 | Debian       | 9 / 10           | ARM / x86_64 / i386 |
 | Fedora       | 31 / 32          | ARM / x86_64        |

--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -24,7 +24,7 @@ The following operating systems are **officially** supported:
 
 | Distribution | Release          | Architecture        |
 | ------------ | ---------------- | ------------------- |
-| Raspberry Pi OS <br>(Raspbian)     | Stretch / Buster | ARM                 |
+| Raspberry Pi OS <br>(formerly Raspbian)     | Stretch / Buster | ARM                 |
 | Ubuntu       | 16.x / 18.x / 20.x      | ARM / x86_64        |
 | Debian       | 9 / 10           | ARM / x86_64 / i386 |
 | Fedora       | 31 / 32          | ARM / x86_64        |

--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -24,7 +24,7 @@ The following operating systems are **officially** supported:
 
 | Distribution | Release          | Architecture        |
 | ------------ | ---------------- | ------------------- |
-| Raspberry Pi OS  (Raspbian)     | Stretch / Buster | ARM                 |
+| Raspberry Pi OS <br>(Raspbian)     | Stretch / Buster | ARM                 |
 | Ubuntu       | 16.x / 18.x / 20.x      | ARM / x86_64        |
 | Debian       | 9 / 10           | ARM / x86_64 / i386 |
 | Fedora       | 31 / 32          | ARM / x86_64        |


### PR DESCRIPTION
Raspbian was officially renamed to  Raspberry Pi OS.
This PR reflects this by changing the name in "supported OS" table