### PR TITLE
Add official Pi-hole WireGuard guide

### DIFF
--- a/docs/abbreviations.md
+++ b/docs/abbreviations.md
@@ -38,3 +38,4 @@
 *[SSH]: Secure Shell is a cryptographic network protocol for operating network services securely over an unsecured network
 *[TFTP]: Trivial File Transfer Protocol is a simple lockstep File Transfer Protocol which allows a client to get a file from or put a file onto a remote host
 *[TTL]: Time-To-Live is a mechanism that limits the lifespan or lifetime of data in a computer or network
+*[NAT]: Network address translation

--- a/docs/abbreviations.md
+++ b/docs/abbreviations.md
@@ -39,3 +39,4 @@
 *[TFTP]: Trivial File Transfer Protocol is a simple lockstep File Transfer Protocol which allows a client to get a file from or put a file onto a remote host
 *[TTL]: Time-To-Live is a mechanism that limits the lifespan or lifetime of data in a computer or network
 *[NAT]: Network address translation
+*[DnyDNS]: Dynamic DNS record pointing to a frequently changing IP address

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -80,7 +80,7 @@ systemctl restart wg-quick@wg0
 
 After a restart, the server file should look like:
 
-```toml
+```bash
 [Interface]
 Address = 10.100.0.1/24, fd08::1/128
 ListenPort = 47111
@@ -132,7 +132,7 @@ echo "PrivateKey = $(cat "${name}.key")" >> "${name}.conf"
 
 Next, add your server as peer for this client:
 
-```toml
+```bash
 [Peer]
 AllowedIPs = 10.100.0.0/24, fd08::/64
 Endpoint = [your public IP or domain]:47111

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -31,25 +31,25 @@ Add the new client by running the command:
 echo "[Peer]" >> /etc/wireguard/wg0.conf
 echo "PublicKey = $(cat NAME.pub)" >> /etc/wireguard/wg0.conf
 echo "PresharedKey = $(cat NAME.psk)" >> /etc/wireguard/wg0.conf
-echo "AllowedIPs = 10.100.0.2/32" >> /etc/wireguard/wg0.conf
+echo "AllowedIPs = 10.100.0.2/32, fd08:4711::2/128" >> /etc/wireguard/wg0.conf
 ```
 
 <!-- markdownlint-disable code-block-style -->
 !!! info "Client IP address"
-    Make sure to increment the IP address for any further client! We add the first client with the IP address `10.100.0.2` in this example (`10.100.0.1` is the server)
+    Make sure to increment the IP address for any further client! We add the first client with the IP addresses `10.100.0.2` and `fd08:4711::2/128` in this example (`10.100.0.1` and `fd08:4711::1/128` are the server)
 <!-- markdownlint-disable code-block-style -->
 
 Restart your server to load the new client config:
 
 ``` bash
-sudo service wg-quick@wg0 restart
+systemctl restart wg-quick@wg0
 ```
 
 After a restart, the server file should look like:
 
 ``` toml
 [Interface]
-Address = 10.100.0.1/24
+Address = 10.100.0.1/24, fd08::1/128
 ListenPort = 47111
 SaveConfig = true
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
@@ -57,7 +57,7 @@ PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 [Peer]
 PublicKey = F+80gbmHVlOrU+es13S18oMEX2g=     # PublicKey will be different
 PresharedKey = 8cLaY8Bkd7PiUs0izYBQYVTEFlA=  # PresharedKey will be different
-AllowedIPs = 10.100.0.2/32
+AllowedIPs = 10.100.0.2/32, fd08:4711::2/128
 
 # Possibly further [Peer] lines
 ```
@@ -78,7 +78,7 @@ interface: wg0
 
 peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be different
   preshared key: (hidden)
-  allowed ips: 10.100.0.2/32
+  allowed ips: 10.100.0.2/32, fd08::2/128
 ```
 
 ## Create client configuration
@@ -93,8 +93,8 @@ with the content
 
 ``` toml
 [Interface]
-Address = 10.100.0.2/32 # Replace this IP address for subsequent clients
-DNS = 10.100.0.1        # IP address of your server (Pi-hole)
+Address = 10.100.0.2/32, fd08:4711::2/128 # Replace this IP address for subsequent clients
+DNS = 10.100.0.1                     # IP address of your server (Pi-hole)
 ```
 
 and add the private key of this client
@@ -107,7 +107,7 @@ Next, add your server as peer for this client:
 
 ``` toml
 [Peer]
-AllowedIPs = 10.100.0.0/24
+AllowedIPs = 10.100.0.0/24, fd08::/64
 Endpoint = [your public IP or domain]:47111
 PersistentKeepalive = 25
 ```
@@ -117,6 +117,7 @@ Then add the public key of the server as well as the PSK for this connection:
 ``` bash
 echo "PublicKey = $(cat server.pub)" >> NAME.conf
 echo "PresharedKey = $(cat NAME.psk)" >> NAME.conf
+exit
 ```
 
 That's it.
@@ -139,7 +140,7 @@ That's it.
 You can now copy the configuration file to your client (if you created the config on the server). If the client is a mobile device such as a phone, `qrencode` can be used to generate a scanable QR code:
 
 ``` bash
-qrencode -t ansiutf8 -r NAME.conf
+sudo qrencode -t ansiutf8 -r /etc/wireguard/NAME.conf
 ```
 
 (you may need to install `qrencode` using `sudo apt-get install qrencode`)
@@ -153,7 +154,7 @@ After creating/copying the connection information over to your client, you may u
 You can check if your client successfully connected by, once again, running
 
 ``` plain
-wg
+sudo wg
 ```
 
 on the server. It should show some traffic for your client if everything works:

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -94,7 +94,7 @@ with the content
 ``` toml
 [Interface]
 Address = 10.100.0.2/32, fd08:4711::2/128 # Replace this IP address for subsequent clients
-DNS = 10.100.0.1                     # IP address of your server (Pi-hole)
+DNS = 10.100.0.1                          # IP address of your server (Pi-hole)
 ```
 
 and add the private key of this client

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -12,7 +12,8 @@ We generate a key-pair for the client `NAME` (replace accordingly everywhere bel
 sudo -i
 cd /etc/wireguard
 umask 077
-wg genkey | tee NAME.key | wg pubkey > NAME.pub
+name="client_name"
+wg genkey | tee "${name}.key" | wg pubkey > "${name}.pub"
 ```
 
 ## PSK Key generation
@@ -20,7 +21,7 @@ wg genkey | tee NAME.key | wg pubkey > NAME.pub
 We furthermore recommend generating a pre-shared key (PSK) in addition to the keys above. This adds an additional layer of symmetric-key cryptography to be mixed into the already existing public-key cryptography and is mainly for post-quantum resistance. A pre-shared key should be generated for each peer pair and *should not be reused*.
 
 ``` bash
-wg genpsk > NAME.psk
+wg genpsk > "${name}.psk"
 ```
 
 ## Add client to server configuration
@@ -29,8 +30,8 @@ Add the new client by running the command:
 
 ``` bash
 echo "[Peer]" >> /etc/wireguard/wg0.conf
-echo "PublicKey = $(cat NAME.pub)" >> /etc/wireguard/wg0.conf
-echo "PresharedKey = $(cat NAME.psk)" >> /etc/wireguard/wg0.conf
+echo "PublicKey = $(cat "${name}.pub")" >> /etc/wireguard/wg0.conf
+echo "PresharedKey = $(cat "${name}.psk")" >> /etc/wireguard/wg0.conf
 echo "AllowedIPs = 10.100.0.2/32, fd08:4711::2/128" >> /etc/wireguard/wg0.conf
 ```
 
@@ -86,7 +87,7 @@ peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be differen
 Create a dedicated config file for your new client:
 
 ``` bash
-nano NAME.conf
+nano "${name}.conf"
 ```
 
 with the content
@@ -100,7 +101,7 @@ DNS = 10.100.0.1                          # IP address of your server (Pi-hole)
 and add the private key of this client
 
 ``` bash
-echo "PrivateKey = $(cat NAME.key)" >> NAME.conf
+echo "PrivateKey = $(cat "${name}.key")" >> "${name}.conf"
 ```
 
 Next, add your server as peer for this client:
@@ -115,8 +116,8 @@ PersistentKeepalive = 25
 Then add the public key of the server as well as the PSK for this connection:
 
 ``` bash
-echo "PublicKey = $(cat server.pub)" >> NAME.conf
-echo "PresharedKey = $(cat NAME.psk)" >> NAME.conf
+echo "PublicKey = $(cat server.pub)" >> "${name}.conf"
+echo "PresharedKey = $(cat "${name}.psk")" >> "${name}.conf"
 exit
 ```
 
@@ -140,7 +141,7 @@ That's it.
 You can now copy the configuration file to your client (if you created the config on the server). If the client is a mobile device such as a phone, `qrencode` can be used to generate a scanable QR code:
 
 ``` bash
-sudo qrencode -t ansiutf8 -r /etc/wireguard/NAME.conf
+sudo qrencode -t ansiutf8 -r "/etc/wireguard/${name}.conf"
 ```
 
 (you may need to install `qrencode` using `sudo apt-get install qrencode`)

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -52,7 +52,7 @@ After a restart, the server file should look like:
 ``` toml
 [Interface]
 Address = 10.100.0.1/24
-ListenPort = 44711
+ListenPort = 47111
 SaveConfig = true
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 
@@ -77,7 +77,7 @@ should tell you about your new client:
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)
-  listening port: 44711
+  listening port: 47111
 
 peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be different
   preshared key: (hidden)
@@ -111,7 +111,7 @@ Next, add your server as peer for this client:
 ``` toml
 [Peer]
 AllowedIPs = 10.100.0.0/24
-Endpoint = [your public IP or domain]:44711
+Endpoint = [your public IP or domain]:47111
 PersistentKeepalive = 25
 ```
 
@@ -165,7 +165,7 @@ on the server. It should show some traffic for your client if everything works:
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)
-  listening port: 44711
+  listening port: 47111
 
 peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be different
   preshared key: (hidden)
@@ -173,5 +173,11 @@ peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be differen
   latest handshake: 32 seconds ago
   transfer: 3.43 KiB received, 188 B sent
 ```
+
+## Test for DNS leaks
+
+You should run a DNS leak test on [www.dnsleaktest.com](https://www.dnsleaktest.com) to ensure your WireGuard tunnel does not leak DNS requests (so all are processed by your Pi-hole). The expected outcome is that you should only see DNS servers belonging to the upstream DNS destination you selected in Pi-hole. If you configured [Pi-hole as All-Around DNS Solution](../unbound.md), you should only see the public IP address of your WireGuard server and no other DNS server.
+
+See also [What is a DNS leak and why should I care?](https://www.dnsleaktest.com/what-is-a-dns-leak.html) (external link).
 
 {!abbreviations.md!}

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -28,7 +28,10 @@ wg genpsk > NAME.psk
 Add the new client by running the command:
 
 ``` bash
-wg set wg0 peer "$(cat NAME.pub)" preshared-key NAME.psk allowed-ips 10.100.0.2/32
+echo "[Peer]" >> /etc/wireguard/wg0.conf
+echo "PublicKey = $(cat NAME.pub)" >> /etc/wireguard/wg0.conf
+echo "PresharedKey = $(cat NAME.psk)" >> /etc/wireguard/wg0.conf
+echo "AllowedIPs = 10.100.0.2/32" >> /etc/wireguard/wg0.conf
 ```
 
 <!-- markdownlint-disable code-block-style -->
@@ -36,16 +39,11 @@ wg set wg0 peer "$(cat NAME.pub)" preshared-key NAME.psk allowed-ips 10.100.0.2/
     Make sure to increment the IP address for any further client! We add the first client with the IP address `10.100.0.2` in this example (`10.100.0.1` is the server)
 <!-- markdownlint-disable code-block-style -->
 
-Restart your server to have it save your client to its config file:
+Restart your server to load the new client config:
 
 ``` bash
 sudo service wg-quick@wg0 restart
 ```
-
-<!-- markdownlint-disable code-block-style -->
-!!! info "Restarting is optional"
-    Note that restarting the WireGuard server is optional and can be skiped. The new client will be stored in the config file on the next restart of the system. However, in case of powerloss, you will loose your new client which is why we restarting the server here (if this can be afforded).
-<!-- markdownlint-disable code-block-style -->
 
 After a restart, the server file should look like:
 
@@ -57,10 +55,9 @@ SaveConfig = true
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 
 [Peer]
-Address = 10.100.0.2/24
-AllowedIPs = 10.100.0.1/32
 PublicKey = F+80gbmHVlOrU+es13S18oMEX2g=     # PublicKey will be different
 PresharedKey = 8cLaY8Bkd7PiUs0izYBQYVTEFlA=  # PresharedKey will be different
+AllowedIPs = 10.100.0.2/32
 
 # Possibly further [Peer] lines
 ```

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -6,7 +6,7 @@ For each new client, the following steps must be taken. For the sake of simplici
 
 <!-- markdownlint-disable code-block-style -->
 ??? info "All commands described below at once"
-    ``` bash
+    ```bash
     sudo -i
     cd /etc/wireguard
     umask 077
@@ -40,7 +40,7 @@ For each new client, the following steps must be taken. For the sake of simplici
 
 We generate a key-pair for the client `NAME` (replace accordingly everywhere below):
 
-``` bash
+```bash
 sudo -i
 cd /etc/wireguard
 umask 077
@@ -52,7 +52,7 @@ wg genkey | tee "${name}.key" | wg pubkey > "${name}.pub"
 
 We furthermore recommend generating a pre-shared key (PSK) in addition to the keys above. This adds an additional layer of symmetric-key cryptography to be mixed into the already existing public-key cryptography and is mainly for post-quantum resistance. A pre-shared key should be generated for each peer pair and *should not be reused*.
 
-``` bash
+```bash
 wg genpsk > "${name}.psk"
 ```
 
@@ -60,7 +60,7 @@ wg genpsk > "${name}.psk"
 
 Add the new client by running the command:
 
-``` bash
+```bash
 echo "[Peer]" >> /etc/wireguard/wg0.conf
 echo "PublicKey = $(cat "${name}.pub")" >> /etc/wireguard/wg0.conf
 echo "PresharedKey = $(cat "${name}.psk")" >> /etc/wireguard/wg0.conf
@@ -74,13 +74,13 @@ echo "AllowedIPs = 10.100.0.2/32, fd08:4711::2/128" >> /etc/wireguard/wg0.conf
 
 Restart your server to load the new client config:
 
-``` bash
+```bash
 systemctl restart wg-quick@wg0
 ```
 
 After a restart, the server file should look like:
 
-``` toml
+```toml
 [Interface]
 Address = 10.100.0.1/24, fd08::1/128
 ListenPort = 47111
@@ -97,13 +97,13 @@ AllowedIPs = 10.100.0.2/32, fd08:4711::2/128
 
 The command
 
-``` bash
+```bash
 wg
 ```
 
 should tell you about your new client:
 
-``` plain
+```plain
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)
@@ -118,7 +118,7 @@ peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be differen
 
 Create a dedicated config file for your new client:
 
-``` bash
+```bash
 echo "[Interface]" > "${name}.conf"
 echo "Address = 10.100.0.2/32, fd08:4711::2/128" >> "${name}.conf" # May need editing
 echo "DNS = 10.100.0.1" >> "${name}.conf"                          # Your Pi-hole's IP
@@ -126,13 +126,13 @@ echo "DNS = 10.100.0.1" >> "${name}.conf"                          # Your Pi-hol
 
 and add the private key of this client
 
-``` bash
+```bash
 echo "PrivateKey = $(cat "${name}.key")" >> "${name}.conf"
 ```
 
 Next, add your server as peer for this client:
 
-``` toml
+```toml
 [Peer]
 AllowedIPs = 10.100.0.0/24, fd08::/64
 Endpoint = [your public IP or domain]:47111
@@ -141,7 +141,7 @@ PersistentKeepalive = 25
 
 Then add the public key of the server as well as the PSK for this connection:
 
-``` bash
+```bash
 echo "PublicKey = $(cat server.pub)" >> "${name}.conf"
 echo "PresharedKey = $(cat "${name}.psk")" >> "${name}.conf"
 exit
@@ -158,7 +158,7 @@ That's it.
     When this option is enabled, a keepalive packet is sent to the server endpoint once every interval seconds. A sensible interval that works with a wide variety of firewalls is `25` seconds. Setting it to 0 turns the feature off, which is the default.
 
     Handshakes are not the same as keep-alives. A handshake establishes a limited-time session of about 3 minutes. So, for about 3 minutes your client is able to send its keep-alive packets without requireing a new session. Then, when the session expires, sending a new keep-alive requires a new session for which you should see a new handshake. In practice, the client initiates a handshake earlier.
-    
+
     **TL;DR** If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent, this option will keep the "connection" open in the eyes of NAT.
 <!-- markdownlint-disable code-block-style -->
 
@@ -166,7 +166,7 @@ That's it.
 
 You can now copy the configuration file to your client (if you created the config on the server). If the client is a mobile device such as a phone, `qrencode` can be used to generate a scanable QR code:
 
-``` bash
+```bash
 sudo qrencode -t ansiutf8 -r "/etc/wireguard/${name}.conf"
 ```
 
@@ -180,13 +180,13 @@ After creating/copying the connection information over to your client, you may u
 
 You can check if your client successfully connected by, once again, running
 
-``` plain
+```plain
 sudo wg
 ```
 
 on the server. It should show some traffic for your client if everything works:
 
-``` plain
+```plain
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -1,0 +1,111 @@
+# Adding a WireGuard client
+
+Adding clients is really simple and easy. The process for setting up a client is similar to setting up the server. This is expected as WireGuard's concept is more of the type Peer-to-Peer than server-client as mentioned at the very beginning of the [Server configuration](server.md).
+
+For each new client, the following steps must be taken. For the sake of simplicity, we will create the config file on the server itself. This, however, means that you need to transfer the config file *securely* to your server as it contains the private key of your client. An alternative way of doing this is to generate the configuration locally on your client and add the necessary lines to your server's configuration.
+
+## Key generation
+
+We generate a key-pair for the client `NAME` (replace accordingly everywhere below):
+
+``` bash
+sudo -i
+cd /etc/wireguard
+umask 077
+wg genkey | tee NAME.key | wg pubkey > NAME.pub
+```
+
+## PSK Key generation
+
+We furthermore recommend generating a pre-shared key (PSK) in addition to the keys above. This adds an additional layer of symmetric-key cryptography to be mixed into the already existing public-key cryptography and is mainly for post-quantum resistance. A pre-shared key should be generated for each peer pair and *should not be reused*.
+
+``` bash
+wg genpsk > NAME.psk
+```
+
+## Add client to server configuration
+
+Add the following to your `/etc/wireguard/wg0.conf`:
+
+``` toml
+[Peer]
+Address = 10.100.0.2/24      # Replace this IP address for subsequent clients
+AllowedIPs = 10.100.0.1/32   # This client is only allowed to talk to the server
+```
+
+Then run
+
+``` bash
+echo "PublicKey = $(cat NAME.pub)" >> /etc/wireguard/wg0.conf
+echo "PresharedKey = $(cat NAME.psk)" >> /etc/wireguard/wg0.conf
+```
+
+to copy the clients's public and pre-shared keys into the server's config file.
+
+## Create client configuration
+
+Create a dedicated config file for your new client:
+
+``` bash
+nano NAME.conf
+```
+
+with the content
+
+``` toml
+[Interface]
+Address = 10.100.0.2/24 # Replace this IP address for subsequent clients
+DNS = 10.100.0.1        # IP address of your Pi-hole
+Domains = ~.            # Enforce all DNS over the WireGuard connection
+```
+
+``` bash
+echo "PrivateKey = $(cat NAME.key)" >> NAME.conf
+```
+
+Then add your server as the only peer for this client:
+
+``` toml
+[Peer]
+AllowedIPs = 10.0.0.1/24
+Endpoint = [your public IP or domain]:44711
+PersistentKeepalive = 25
+```
+
+Make sure that each IP is used only once.
+
+<!-- markdownlint-disable code-block-style -->
+??? info "About the `PersistentKeepalive` setting"
+    By default WireGuard peers remain silent while they do not need to communicate, so peers located behind a NAT and/or firewall may be unreachable from other peers until they reach out to other peers themselves (or the connection may time out).
+
+    When a peer is behind NAT or a firewall, it typically wants to be able to receive incoming packets even when it is not sending any packets itself. Because NAT and stateful firewalls keep track of "connections", if a peer behind NAT or a firewall wishes to receive incoming packets, he must keep the NAT/firewall mapping valid, by periodically sending keepalive packets. This is called *persistent keepalives*.
+
+    When this option is enabled, a keepalive packet is sent to the server endpoint once every interval seconds. A sensible interval that works with a wide variety of firewalls is `25` seconds. Setting it to 0 turns the feature off, which is the default.
+    
+    **TL;DR** If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent, this option will keep the "connection" open in the eyes of NAT.
+<!-- markdownlint-disable code-block-style -->
+
+Then add the public key of the server as well as the PSK for this connection:
+
+``` bash
+echo "PublicKey = $(cat server.pub)" >> NAME.conf
+echo "PresharedKey = $(cat NAME.psk)" >> NAME.conf
+```
+
+That's it.
+
+## Copy config file to client
+
+You can now copy the configuration file to your client (if you created the config on the server). If the client is a mobile device such as a phone, `qrencode` can be used to generate a scanable QR code:
+
+``` bash
+qrencode -t ansiutf8 -r NAME.conf
+```
+
+(you may need to install `qrencode` using `sudo apt-get install qrencode`)
+
+## Connect to your WireGuard VPN
+
+After creating/copying the connection information over to your client, you may use the client you prefer to connect to your system. Mind that setting up auto-start of the WireGuard connection may lead to issues if you are doing this too early (when the system cannot resolve DNS). See our [FAQ](faq.md) for further hints.
+
+{!abbreviations.md!}

--- a/docs/guides/wireguard/client.md
+++ b/docs/guides/wireguard/client.md
@@ -6,7 +6,7 @@ For each new client, the following steps must be taken. For the sake of simplici
 
 <!-- markdownlint-disable code-block-style -->
 ??? info "All commands described below at once"
-    ```bash
+    ``` bash
     sudo -i
     cd /etc/wireguard
     umask 077
@@ -40,7 +40,7 @@ For each new client, the following steps must be taken. For the sake of simplici
 
 We generate a key-pair for the client `NAME` (replace accordingly everywhere below):
 
-```bash
+``` bash
 sudo -i
 cd /etc/wireguard
 umask 077
@@ -52,7 +52,7 @@ wg genkey | tee "${name}.key" | wg pubkey > "${name}.pub"
 
 We furthermore recommend generating a pre-shared key (PSK) in addition to the keys above. This adds an additional layer of symmetric-key cryptography to be mixed into the already existing public-key cryptography and is mainly for post-quantum resistance. A pre-shared key should be generated for each peer pair and *should not be reused*.
 
-```bash
+``` bash
 wg genpsk > "${name}.psk"
 ```
 
@@ -60,7 +60,7 @@ wg genpsk > "${name}.psk"
 
 Add the new client by running the command:
 
-```bash
+``` bash
 echo "[Peer]" >> /etc/wireguard/wg0.conf
 echo "PublicKey = $(cat "${name}.pub")" >> /etc/wireguard/wg0.conf
 echo "PresharedKey = $(cat "${name}.psk")" >> /etc/wireguard/wg0.conf
@@ -74,13 +74,13 @@ echo "AllowedIPs = 10.100.0.2/32, fd08:4711::2/128" >> /etc/wireguard/wg0.conf
 
 Restart your server to load the new client config:
 
-```bash
+``` bash
 systemctl restart wg-quick@wg0
 ```
 
 After a restart, the server file should look like:
 
-```bash
+``` plain
 [Interface]
 Address = 10.100.0.1/24, fd08::1/128
 ListenPort = 47111
@@ -97,13 +97,13 @@ AllowedIPs = 10.100.0.2/32, fd08:4711::2/128
 
 The command
 
-```bash
+``` bash
 wg
 ```
 
 should tell you about your new client:
 
-```plain
+``` plain
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)
@@ -118,7 +118,7 @@ peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be differen
 
 Create a dedicated config file for your new client:
 
-```bash
+``` bash
 echo "[Interface]" > "${name}.conf"
 echo "Address = 10.100.0.2/32, fd08:4711::2/128" >> "${name}.conf" # May need editing
 echo "DNS = 10.100.0.1" >> "${name}.conf"                          # Your Pi-hole's IP
@@ -126,13 +126,13 @@ echo "DNS = 10.100.0.1" >> "${name}.conf"                          # Your Pi-hol
 
 and add the private key of this client
 
-```bash
+``` bash
 echo "PrivateKey = $(cat "${name}.key")" >> "${name}.conf"
 ```
 
 Next, add your server as peer for this client:
 
-```bash
+``` plain
 [Peer]
 AllowedIPs = 10.100.0.0/24, fd08::/64
 Endpoint = [your public IP or domain]:47111
@@ -141,7 +141,7 @@ PersistentKeepalive = 25
 
 Then add the public key of the server as well as the PSK for this connection:
 
-```bash
+``` bash
 echo "PublicKey = $(cat server.pub)" >> "${name}.conf"
 echo "PresharedKey = $(cat "${name}.psk")" >> "${name}.conf"
 exit
@@ -166,7 +166,7 @@ That's it.
 
 You can now copy the configuration file to your client (if you created the config on the server). If the client is a mobile device such as a phone, `qrencode` can be used to generate a scanable QR code:
 
-```bash
+``` bash
 sudo qrencode -t ansiutf8 -r "/etc/wireguard/${name}.conf"
 ```
 
@@ -180,13 +180,13 @@ After creating/copying the connection information over to your client, you may u
 
 You can check if your client successfully connected by, once again, running
 
-```plain
+``` bash
 sudo wg
 ```
 
 on the server. It should show some traffic for your client if everything works:
 
-```plain
+``` plain
 interface: wg0
   public key: XYZ123456ABC=          ⬅ Your server's public key will be different
   private key: (hidden)

--- a/docs/guides/wireguard/concept.md
+++ b/docs/guides/wireguard/concept.md
@@ -1,0 +1,32 @@
+# Conceptual overview
+
+Before we get started with installing a `wireguard` server, we'll quickly give a general conceptual overview of what WireGuard is about. You can skip this section if you already know what is going on under the hood or don't care (and just want to have it running).
+
+WireGuard securely encapsulates IP packets over UDP. You add a WireGuard interface, configure it with your private key and your peers' public keys, and then you send packets across it.
+
+WireGuard works by adding a network interface, like `eth0` or `wlan0`, called `wg0` (or `wg1`,
+`wg2`, `wg3`, etc). This interface acts as a tunnel interface. Routes for this network interface will be added automatically based on the configuration file you will learn about below. All aspects of this virtual interface will be configured automatically by the `wg-tools`.
+
+WireGuard associates tunnel IP addresses with public keys and remote endpoints. When the interface
+**sends a packet to a peer**, it does the following:
+
+1. This packet is meant for `192.168.30.8`. Is this peer configured?
+    1. Yes: peer `adams-laptop`. Continue with step 2.
+    2. No: Not for any configured peer, drop the packet and end here.
+
+2. Encrypt the IP packet using peer `adams-laptop`'s public key.
+3. What is the remote endpoint of peer `adams-laptop`? Let me look... Okay, the endpoint is host `216.58.211.110:53133` (UDP).
+4. Send encrypted data over the Internet to this host.
+
+When the interface **receives a packet from a peer**, this happens:
+
+1. Received a packet from host `98.139.183.24:7361`. Let's decrypt it!
+2. It decrypted and authenticated properly for peer `evas-android`. Okay, let's remember that peer
+`evas-android`'s most recent Internet endpoint is `98.139.183.24:7361` (UDP).
+3. Once decrypted, the plain-text packet is from `192.168.43.89`. Is peer `evas-android` allowed to be sending us packets as 192.168.43.89?
+    1. Yes: accept the packet on the interface and process it (forwarding to further local client, into the Internet, etc.)
+    2. No: drop it.
+
+Behind the scenes there is much happening to provide proper privacy, authenticity, and perfect forward secrecy, using state-of-the-art cryptography.
+
+If you're interested in the internal inner workings, you might be interested in reading through the various articles on their official website [www.wireguard.com](https://www.wireguard.com) which is also where we took the vast majority of content in this guide from.

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -1,0 +1,85 @@
+# Frequently asked questions
+
+## Issues with dynamic server IP
+
+Host names cannot be resolved during startup. This may lead to a five minutes delay during boot. A solution to this is to disable the automatic start of the `wg` interface during start and connect only later (manually) when you are sure that you can resolve host names.
+
+1. Disable `auto wg0` in `/etc/network/interfaces` (put `#` in front, like `#auto wg0`)
+2. Start `wireguard` manually using `sudo ifup wg0`
+
+If the IP changes while the connection is running, resolving the new IP address fails otten. Reconnect using
+
+``` bash
+sudo ifdown wg0 && sudo ifup wg0
+```
+
+To achieve a permanent solution, one can install a `cron` job which restarts the connection automatically whenever a change is detected. This avoids excessive restarts of the interface. Example script (taken from [Ubuntuusers Wiki](https://wiki.ubuntuusers.de/WireGuard)):
+
+``` bash
+#!/bin/bash
+# Check state of wg0 interface
+wgstatus=$(wg)
+if [ "$wgstatus" == "interface: wg0" ]; then
+    ip link delete wg0 && ifup wg0
+elif [ "$wgstatus" == "interface: wg0" ]; then
+    ifup wg0
+else
+    file="/tmp/digIP.txt"
+    digIP=$(dig +short beispiel2.domain.de) # Change this to your domain !
+    if [ -e "$file" ]; then
+        fileTXT=$(cat "$file")
+        if [ "$digIP" != "$fileTXT" ]; then
+            #echo "Daten sind gleich"
+            /sbin/ifdown wg0
+            /sbin/ifup wg0
+            echo "$digIP" > "$file"
+        fi
+    else
+        echo "$digIP" > "$file"
+    fi
+fi
+```
+
+Store this file as `/home/[user name]/wg-restart.sh` and add it to your `crontab`:
+
+``` bash
+sudo crontab -e
+```
+
+``` plain
+*/10 * * * * bash /home/[user name]/wg-restart.sh    # Runs the script every 10 minutes
+```
+
+## Routes are periodically reset
+
+Users of NetworkManager should make sure that it is not managing the WireGuard interface(s). For example, create the configuration file `/etc/NetworkManager/conf.d/unmanaged.conf` with content
+
+``` toml
+[keyfile]
+unmanaged-devices=interface-name:wg*
+```
+
+[source](https://wiki.archlinux.org/index.php/WireGuard)
+
+## Broken DNS resolution
+
+When tunneling all traffic through a WireGuard interface, the connection can become seemingly lost after a while or upon new connection. This could be caused by a network manager or DHCP client overwriting `/etc/resolv.conf`.
+By default, `wg-quick` uses `resolvconf` to register new DNS entries (from the DNS keyword in the configuration file). This will cause issues with network managers and DHCP clients that do not use `resolvconf`, as they will overwrite `/etc/resolv.conf` thus removing the DNS servers added by `wg-quick`.
+
+The solution is to use networking software that supports `resolvconf`.
+
+!!! info "Hint for Ubuntu users"
+    Users of `systemd-resolved` should make sure that `systemd-resolvconf` is installed.
+
+[source](https://wiki.archlinux.org/index.php/WireGuard)
+
+## Low MTU
+
+Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in Interface section on client:
+
+``` toml
+[Interface]
+MTU = 1500
+```
+
+[source](https://wiki.archlinux.org/index.php/WireGuard)

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -9,13 +9,13 @@ Host names cannot be resolved during startup. This may lead to a five minutes de
 
 If the IP changes while the connection is running, resolving the new IP address fails otten. Reconnect using
 
-``` bash
+```bash
 sudo ifdown wg0 && sudo ifup wg0
 ```
 
 To achieve a permanent solution, one can install a `cron` job which restarts the connection automatically whenever a change is detected. This avoids excessive restarts of the interface. Example script (taken from [Ubuntuusers Wiki](https://wiki.ubuntuusers.de/WireGuard)):
 
-``` bash
+```bash
 #!/bin/bash
 # Check state of wg0 interface
 wgstatus=$(wg)
@@ -42,11 +42,11 @@ fi
 
 Store this file as `/home/[user name]/wg-restart.sh` and add it to your `crontab`:
 
-``` bash
+```bash
 sudo crontab -e
 ```
 
-``` plain
+```plain
 */10 * * * * bash /home/[user name]/wg-restart.sh    # Runs the script every 10 minutes
 ```
 
@@ -54,7 +54,7 @@ sudo crontab -e
 
 Users of NetworkManager should make sure that it is not managing the WireGuard interface(s). For example, create the configuration file `/etc/NetworkManager/conf.d/unmanaged.conf` with content
 
-``` toml
+```toml
 [keyfile]
 unmanaged-devices=interface-name:wg*
 ```
@@ -77,7 +77,7 @@ The solution is to use networking software that supports `resolvconf`.
 
 Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in Interface section on client:
 
-``` toml
+```toml
 [Interface]
 MTU = 1500
 ```

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -54,7 +54,7 @@ sudo crontab -e
 
 Users of NetworkManager should make sure that it is not managing the WireGuard interface(s). For example, create the configuration file `/etc/NetworkManager/conf.d/unmanaged.conf` with content
 
-```toml
+```bash
 [keyfile]
 unmanaged-devices=interface-name:wg*
 ```
@@ -77,7 +77,7 @@ The solution is to use networking software that supports `resolvconf`.
 
 Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in the Interface section on the client:
 
-```toml
+```bash
 [Interface]
 MTU = 1500
 ```

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -2,12 +2,12 @@
 
 ## Issues with dynamic server IP
 
-Host names cannot be resolved during startup. This may lead to a five minutes delay during boot. A solution to this is to disable the automatic start of the `wg` interface during start and connect only later (manually) when you are sure that you can resolve host names.
+Hostnames cannot be resolved during startup. This may lead to a five minutes delay during boot. A solution to this is to disable the automatic start of the `wg` interface during start and connect only later (manually) when you are sure that you can resolve hostnames.
 
 1. Disable `auto wg0` in `/etc/network/interfaces` (put `#` in front, like `#auto wg0`)
 2. Start `wireguard` manually using `sudo ifup wg0`
 
-If the IP changes while the connection is running, resolving the new IP address fails otten. Reconnect using
+If the IP changes while the connection is running, resolving the new IP address fails often. Reconnect using
 
 ```bash
 sudo ifdown wg0 && sudo ifup wg0
@@ -63,7 +63,7 @@ unmanaged-devices=interface-name:wg*
 
 ## Broken DNS resolution
 
-When tunneling all traffic through a WireGuard interface, the connection can become seemingly lost after a while or upon new connection. This could be caused by a network manager or DHCP client overwriting `/etc/resolv.conf`.
+When tunneling all traffic through a WireGuard interface, the connection can become seemingly lost after a while or upon a new connection. This could be caused by a network manager or DHCP client overwriting `/etc/resolv.conf`.
 By default, `wg-quick` uses `resolvconf` to register new DNS entries (from the DNS keyword in the configuration file). This will cause issues with network managers and DHCP clients that do not use `resolvconf`, as they will overwrite `/etc/resolv.conf` thus removing the DNS servers added by `wg-quick`.
 
 The solution is to use networking software that supports `resolvconf`.
@@ -75,7 +75,7 @@ The solution is to use networking software that supports `resolvconf`.
 
 ## Low MTU
 
-Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in Interface section on client:
+Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in the Interface section on the client:
 
 ```toml
 [Interface]

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -83,3 +83,13 @@ MTU = 1500
 ```
 
 [source](https://wiki.archlinux.org/index.php/WireGuard)
+
+## Pi-hole not listening on `wg0` after reboot
+
+If, e.g., after reboot, the `wg0` interface isn't up before Pi-hole is ready (more precisely, the `pihole-FTL` service is started), you may experience that Pi-hole doesn't listen on the Wireguard interface. This can be mitigated by artificially delaying the start of Pi-hole using, e.g., the config option
+
+``` plain
+DELAY_STARTUP=5
+```
+
+in `/etc/pihole/pihole-FTL.conf` to have Pi-hole delay the start of the DNS server by `5` seconds.

--- a/docs/guides/wireguard/faq.md
+++ b/docs/guides/wireguard/faq.md
@@ -9,13 +9,13 @@ Hostnames cannot be resolved during startup. This may lead to a five minutes del
 
 If the IP changes while the connection is running, resolving the new IP address fails often. Reconnect using
 
-```bash
+``` bash
 sudo ifdown wg0 && sudo ifup wg0
 ```
 
 To achieve a permanent solution, one can install a `cron` job which restarts the connection automatically whenever a change is detected. This avoids excessive restarts of the interface. Example script (taken from [Ubuntuusers Wiki](https://wiki.ubuntuusers.de/WireGuard)):
 
-```bash
+``` bash
 #!/bin/bash
 # Check state of wg0 interface
 wgstatus=$(wg)
@@ -42,11 +42,11 @@ fi
 
 Store this file as `/home/[user name]/wg-restart.sh` and add it to your `crontab`:
 
-```bash
+``` bash
 sudo crontab -e
 ```
 
-```plain
+``` plain
 */10 * * * * bash /home/[user name]/wg-restart.sh    # Runs the script every 10 minutes
 ```
 
@@ -54,7 +54,7 @@ sudo crontab -e
 
 Users of NetworkManager should make sure that it is not managing the WireGuard interface(s). For example, create the configuration file `/etc/NetworkManager/conf.d/unmanaged.conf` with content
 
-```bash
+``` bash
 [keyfile]
 unmanaged-devices=interface-name:wg*
 ```
@@ -77,7 +77,7 @@ The solution is to use networking software that supports `resolvconf`.
 
 Due to too low MTU (lower than 1280), `wg-quick` may fail to create the WireGuard interface. This can be solved by setting the MTU value in WireGuard configuration in the Interface section on the client:
 
-```bash
+``` bash
 [Interface]
 MTU = 1500
 ```

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -1,0 +1,71 @@
+# Access devices in the internal network through the WireGuard tunnel
+
+## Enable IP forwarding on the server
+
+Enable IP forwarding on your server by removing the comments in front of
+
+``` toml
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+```
+
+in the file `/etc/sysctl.d/99-sysctl.conf`
+
+Then apply the new option with the command below.
+
+``` bash
+sudo sysctl -p
+```
+
+If you see the options repeated like
+
+``` plain
+net.ipv4.ip_forward=1
+```
+
+they were enabled successfully.
+
+A properly configured firewall is ***highly*** recommended for any Internet-facing device. Configuring a firewall (`iptables`, `ufw`, etc.) is not part of this guide.
+
+## Enable NAT on the server
+
+!!! info "Optional for NAT"
+    If the server is behind a router and receives traffic via NAT, these iptables rules are not needed.
+
+On your server, add the following to the `[INTERFACE]` section:
+
+``` toml
+PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+```
+
+!!! warning "Substitute interface"
+    Substitute `eth0` in the preceding lines to match the Internet-facing interface.
+
+??? info "The `PostUp` and `PostDown` options"
+    `PostUp` and `PostDown` defines steps to be run after the interface is turned on or off, respectively. In this case, iptables is used to set Linux IP masquerade rules to allow all the clients to share the server’s IPv4 and IPv6 address.
+    The rules will then be cleared once the tunnel is down.
+
+## Allow clients to access other devices
+
+In our standard configuration, we have configured the clients in such a way that they can only speak to the server. This has to be changed on both the server and the clients.
+
+### Server side
+
+``` toml
+[Peer]
+AllowedIPs = 10.100.0.1/32
+```
+
+Change this to
+
+``` toml
+[Peer]
+AllowedIPs = 10.100.0.1/32, 192.168.2.1/24
+```
+
+if your internal network is in the IP range `192.168.2.1` - `192.168.2.254`.
+
+### Client side
+
+Do the same in the `[Interface]` section.

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -4,7 +4,7 @@
 
 Enable IP forwarding on your server by removing the comments in front of
 
-``` toml
+```toml
 net.ipv4.ip_forward = 1
 net.ipv6.conf.all.forwarding = 1
 ```
@@ -13,13 +13,13 @@ in the file `/etc/sysctl.d/99-sysctl.conf`
 
 Then apply the new option with the command below.
 
-``` bash
+```bash
 sudo sysctl -p
 ```
 
 If you see the options repeated like
 
-``` plain
+```plain
 net.ipv4.ip_forward=1
 net.ipv6.conf.all.forwarding = 1
 ```
@@ -35,7 +35,7 @@ A properly configured firewall is ***highly*** recommended for any Internet-faci
 
 On your server, add the following to the `[INTERFACE]` section of your `/etc/wireguard/wg0.conf`:
 
-``` toml
+```toml
 PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE
 ```
@@ -55,14 +55,14 @@ In our standard configuration, we have configured the clients in such a way that
 
 Change the allowed addresses in your `/etc/wireguard/wg0.conf` from
 
-``` toml
+```toml
 [Peer]
 AllowedIPs = 10.100.0.1/32, fd08:4711::1/64
 ```
 
 to
 
-``` toml
+```toml
 [Peer]
 AllowedIPs = 10.100.0.0/24, fd08:4711::/64, 192.168.2.0/24
 ```
@@ -73,7 +73,7 @@ assuming your internal network is in the IP range `192.168.2.1` - `192.168.2.254
 
 Do the same you did above for the server also in the `[Interface]` section of all clients you want to have this feature:
 
-``` toml
+```toml
 [Peer]
 AllowedIPs = 10.0.0.0/24, fd08:4711::/64, 192.168.2.0/24
 ```

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -21,6 +21,7 @@ If you see the options repeated like
 
 ``` plain
 net.ipv4.ip_forward=1
+net.ipv6.conf.all.forwarding = 1
 ```
 
 they were enabled successfully.
@@ -68,4 +69,4 @@ if your internal network is in the IP range `192.168.2.1` - `192.168.2.254`.
 
 ### Client side
 
-Do the same in the `[Interface]` section.
+Do the same you did above for the server also in the `[Interface]` section of all clients you want to have this feature. It is possible to add this only for a few clients, leaving the others isolated to only the Pi-hole server itself.

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -1,4 +1,4 @@
-# Access devices in the internal network through the WireGuard tunnel
+# Access internal devices through the WireGuard tunnel
 
 ## Enable IP forwarding on the server
 
@@ -33,7 +33,7 @@ A properly configured firewall is ***highly*** recommended for any Internet-faci
 !!! info "Optional for NAT"
     If the server is behind a router and receives traffic via NAT, these iptables rules are not needed.
 
-On your server, add the following to the `[INTERFACE]` section:
+On your server, add the following to the `[INTERFACE]` section of your `/etc/wireguard/wg0.conf`:
 
 ``` toml
 PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
@@ -53,19 +53,21 @@ In our standard configuration, we have configured the clients in such a way that
 
 ### Server side
 
-``` toml
-[Peer]
-AllowedIPs = 10.100.0.1/32
-```
-
-Change this to
+Change the allowed addresses in your `/etc/wireguard/wg0.conf` from
 
 ``` toml
 [Peer]
-AllowedIPs = 10.100.0.1/32, 192.168.2.1/24
+AllowedIPs = 10.100.0.1/32, fd08:4711::1/64
 ```
 
-if your internal network is in the IP range `192.168.2.1` - `192.168.2.254`.
+to
+
+``` toml
+[Peer]
+AllowedIPs = 10.100.0.1/32, fd08:4711::1/64, 192.168.2.1/24
+```
+
+assuming your internal network is in the IP range `192.168.2.1` - `192.168.2.254`.
 
 ### Client side
 

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -4,7 +4,7 @@
 
 Enable IP forwarding on your server by removing the comments in front of
 
-```toml
+```bash
 net.ipv4.ip_forward = 1
 net.ipv6.conf.all.forwarding = 1
 ```
@@ -19,8 +19,8 @@ sudo sysctl -p
 
 If you see the options repeated like
 
-```plain
-net.ipv4.ip_forward=1
+```bash
+net.ipv4.ip_forward = 1
 net.ipv6.conf.all.forwarding = 1
 ```
 
@@ -35,7 +35,7 @@ A properly configured firewall is ***highly*** recommended for any Internet-faci
 
 On your server, add the following to the `[INTERFACE]` section of your `/etc/wireguard/wg0.conf`:
 
-```toml
+```bash
 PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE
 ```
@@ -55,14 +55,14 @@ In our standard configuration, we have configured the clients in such a way that
 
 Change the allowed addresses in your `/etc/wireguard/wg0.conf` from
 
-```toml
+```bash
 [Peer]
 AllowedIPs = 10.100.0.1/32, fd08:4711::1/64
 ```
 
 to
 
-```toml
+```bash
 [Peer]
 AllowedIPs = 10.100.0.0/24, fd08:4711::/64, 192.168.2.0/24
 ```
@@ -73,7 +73,7 @@ assuming your internal network is in the IP range `192.168.2.1` - `192.168.2.254
 
 Do the same you did above for the server also in the `[Interface]` section of all clients you want to have this feature:
 
-```toml
+```bash
 [Peer]
 AllowedIPs = 10.0.0.0/24, fd08:4711::/64, 192.168.2.0/24
 ```

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -64,11 +64,19 @@ to
 
 ``` toml
 [Peer]
-AllowedIPs = 10.100.0.1/32, fd08:4711::1/64, 192.168.2.1/24
+AllowedIPs = 10.100.0.0/24, fd08:4711::/64, 192.168.2.0/24
 ```
 
-assuming your internal network is in the IP range `192.168.2.1` - `192.168.2.254`.
+assuming your internal network is in the IP range `192.168.2.1` - `192.168.2.254`. The change `10.100.0.1/32` to `10.100.0.0/24` also allows your WireGuard peers to see each other.
 
 ### Client side
 
-Do the same you did above for the server also in the `[Interface]` section of all clients you want to have this feature. It is possible to add this only for a few clients, leaving the others isolated to only the Pi-hole server itself.
+Do the same you did above for the server also in the `[Interface]` section of all clients you want to have this feature:
+
+``` toml
+[Peer]
+AllowedIPs = 10.0.0.0/24, fd08:4711::/64, 192.168.2.0/24
+```
+
+
+It is possible to add this only for a few clients, leaving the others isolated to only the Pi-hole server itself.

--- a/docs/guides/wireguard/internal.md
+++ b/docs/guides/wireguard/internal.md
@@ -37,24 +37,27 @@ PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -
 PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE
 ```
 
+<!-- markdownlint-disable code-block-style -->
 !!! warning "**Important:** Substitute interface"
     **Without the correct interface name, this will not work!**
 
     Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `ens2p0` or similar on more recent Ubuntu versions (check, e.g., `ip a` for details about your local interfaces).
+<!-- markdownlint-enable code-block-style -->
 
 `PostUp` and `PostDown` defines steps to be run after the interface is turned on or off, respectively. In this case, iptables is used to set Linux IP masquerade rules to allow all the clients to share the server’s IPv4 and IPv6 address.
 The rules will then be cleared once the tunnel is down.
 
+<!-- markdownlint-disable code-block-style -->
 ??? info "Exemplary server config file with this change"
     ``` plain
     [Interface]
     PrivateKey = [your server's private key]
     Address = [Wireguard-internal IPs of the server, e.g. 10.100.0.1/24, fd08:4711::1/64]
     ListenPort = 47111
-    
+
     PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o enp2s0 -j MASQUERADE
     PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o enp2s0 -j MASQUERADE
-    
+
     # Android phone
     [Peer]
     PublicKey = [public key of this client]
@@ -65,7 +68,7 @@ The rules will then be cleared once the tunnel is down.
     ```
 
     The important change is the extra PostUp` and `PostDown` in the `[Interface]` section.
-
+<!-- markdownlint-enable code-block-style -->
 ## Allow clients to access other devices
 
 In our standard configuration, we have configured the clients in such a way that they can only speak to the server. Add the network range of your local network in CIDR notation (e.g., `192.168.2.1 - 192.168.2.254` -> `192.168.2.0/24`) in the `[Peers]` section of all clients you want to have this feature:
@@ -77,6 +80,7 @@ AllowedIPs = 10.0.0.0/24, fd08:4711::/64, 192.168.2.0/24
 
 It is possible to add this only for a few clients, leaving the others isolated to only the Pi-hole server itself.
 
+<!-- markdownlint-disable code-block-style -->
 ??? info "Exemplary client config file with this change"
     ``` plain
     [Interface]
@@ -93,3 +97,4 @@ It is possible to add this only for a few clients, leaving the others isolated t
     ```
 
     The important change is the extra `192.168.2.0/24` at the end of the `[Peer] -> AllowedIPs` entry.
+<!-- markdownlint-enable code-block-style -->

--- a/docs/guides/wireguard/overview.md
+++ b/docs/guides/wireguard/overview.md
@@ -1,0 +1,30 @@
+### Remote accessing Pi-hole using WireGuard
+
+WireGuard is an ***extremely simple yet fast and modern VPN*** that utilizes state-of-the-art cryptography. Comparing to other solutions, such as OpenVPN or IPsec, it aims to be **faster, simpler and leaner** while avoiding the massive overhead involved with other VPN solutions.
+A combination of extremely high-speed cryptographic primitives and the fact that WireGuard lives
+inside the Linux kernel means that secure networking can be very high-speed.
+It intends to be considerably more performant than OpenVPN.
+
+WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many circumstances.
+
+There is no need to manage connections, be concerned about state, manage daemons, or worry about what's under the hood. WireGuard presents an extremely basic yet powerful interface.
+
+Using WireGuard is a modern and safe way to access your Pi-hole's capabilities remotely. Setting up a DNS server has become a simple task with Pi-hole's automated installer, which has resulted in many people knowingly--or unknowingly--creating an open resolver, which aids in DNS Amplification Attacks.
+
+WireGuard has been designed with ease-of-implementation and simplicity in mind. It is meant to be
+easily implemented in very few lines of code, and easily auditable for security vulnerabilities.
+
+This article aims to provide a step-by-step walk-through on setting up a server running Pi-hole and WireGuard so you can securely connect to your Pi-hole's DNS (and *optionally* your entire internal network) from anywhere.
+
+**This tutorial walks you through the installation of a WireGuard server on your Pi-hole**.
+
+Via this VPN, you can:
+
+- use the full filtering capabilities of your Pi-hole
+- access your Pi-hole dashboard remotely
+- access all your internal devices (*optional*)
+- reroute your entire Internet traffic through your Pi-hole (*optional*)
+
+from everywhere around the globe.
+
+{!abbreviations.md!}

--- a/docs/guides/wireguard/overview.md
+++ b/docs/guides/wireguard/overview.md
@@ -1,11 +1,11 @@
 ### Remote accessing Pi-hole using WireGuard
 
-WireGuard is an ***extremely simple yet fast and modern VPN*** that utilizes state-of-the-art cryptography. Comparing to other solutions, such as OpenVPN or IPsec, it aims to be **faster, simpler and leaner** while avoiding the massive overhead involved with other VPN solutions.
+WireGuard is an ***extremely simple yet fast and modern VPN*** that utilizes state-of-the-art cryptography. Comparing to other solutions, such as OpenVPN or IPsec, it aims to be **faster, simpler, and leaner** while avoiding the massive overhead involved with other VPN solutions.
 A combination of extremely high-speed cryptographic primitives and the fact that WireGuard lives
 inside the Linux kernel means that secure networking can be very high-speed.
 It intends to be considerably more performant than OpenVPN.
 
-WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many circumstances.
+WireGuard is designed as a general-purpose VPN for running on embedded interfaces and super computers alike, fit for many circumstances.
 
 There is no need to manage connections, be concerned about state, manage daemons, or worry about what's under the hood. WireGuard presents an extremely basic yet powerful interface.
 

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -4,8 +4,15 @@ Routing your entire Internet traffic is **optional**, however, it can be advanta
 
 Rerouting the Internet traffic through your Pi-hole will furthermore cause all of your Internet traffic to reach the Internet from the place where your WireGuard server is located. This can be used to obfuscate your real location as well as to be allowed to access geo-blocked content, e.g., when your Pi-hole is located in Germany but you are traveling in the United States. If you want to access a page only accessible from within Germany (like the live-broadcast of Tagesschau, etc.), this will typically not work. However, if you route your entire Internet through your Pi-hole, your network traffic will originate from Germany, allowing you to watch the content.
 
-!!! info "Ensure you're already forwarding traffic"
-    The following assumes you have already prepared your Pi-hole for [IP forwarding](internal.md). If this is not the case, follow the steps over there before continuing here.
+<!-- markdownlint-disable code-block-style -->
+!!! info "Create a second profile"
+    Instead of editing your existing configuration, you can easily add a new one with the modified `AllowedIPs` line as above. This will give you two tunnel variants and you decide - at any time from mobile - which variant you want. The one with only the DNS traffic being safely forwarded to your Pi-hole or the variant where your entire Internet traffic is encrypted and sent through your Pi-hole. You can choose at any time which is the best solution in your current situation (e.g., trusted network, unencrypted airport Wi-Fi, etc.).
+<!-- markdownlint-enable code-block-style -->
+
+<!-- markdownlint-disable code-block-style -->
+!!! warning "Ensure you're already forwarding traffic"
+    The following assumes you have already prepared your Pi-hole for [IP forwarding](internal.md#enable-ip-forwarding-on-the-server) and [enabled NAT](internal.md#enable-nat-on-the-server). If this is not the case, follow the steps over there before continuing here.
+<!-- markdownlint-enable code-block-style -->
 
 To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your clients's WireGuard config files:
 

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -2,7 +2,7 @@ Routing your entire Internet traffic is **optional**, however, it can be advanta
 
 Rerouting the Internet traffic through your Pi-hole will furthermore cause all of your Internet traffic to reach the Internet from the place where your WireGuard server is located. This can be used to obfuscate your real location as well as to be allowed to access geo-blocked content, e.g., when your Pi-hole is located in Germany but you are traveling in the United States. If you want to access a page only accessible from within Germany (like the live-broadcast of Tagesschau, etc.), this will typically not work. However, if you route your entire Internet through your Pi-hole, your network traffic will originate from Germany, allowing you to watch the content.
 
-To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your WireGuard config files:
+To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your clients's WireGuard config files:
 
 ```toml
 AllowedIPs = 0.0.0.0/0, ::/0
@@ -10,4 +10,6 @@ AllowedIPs = 0.0.0.0/0, ::/0
 
 Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
 
-That's all you need to do.
+That's all you need to do. You should use an online check (e.g. www.wieistmeineip.de) to check if your IP changed to the public IP address of your WireGuard server after this change up. It is possible to add this change only for a few clients, leaving the others without a full tunnel for all traffic (e.g., where this is not necessary or not desired).
+
+{!abbreviations.md!}

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -1,6 +1,11 @@
+# Route the entire Internet traffic through the WireGuard tunnel
+
 Routing your entire Internet traffic is **optional**, however, it can be advantageous in cases where you are expecting eavesdropping on the network. This may not only happen in unsecure open Wi-Fi networks (airports, hotels, trains, etc.) but also in encrypted Wi-Fi networks where the creator of the network can monitor client activity.
 
 Rerouting the Internet traffic through your Pi-hole will furthermore cause all of your Internet traffic to reach the Internet from the place where your WireGuard server is located. This can be used to obfuscate your real location as well as to be allowed to access geo-blocked content, e.g., when your Pi-hole is located in Germany but you are traveling in the United States. If you want to access a page only accessible from within Germany (like the live-broadcast of Tagesschau, etc.), this will typically not work. However, if you route your entire Internet through your Pi-hole, your network traffic will originate from Germany, allowing you to watch the content.
+
+!!! info "Ensure you're already forwarding traffic"
+    The following assumes you have already prepared your Pi-hole for [IP forwarding](internal.md). If this is not the case, follow the steps over there before continuing here.
 
 To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your clients's WireGuard config files:
 
@@ -8,7 +13,10 @@ To route all traffic through the tunnel to a specific peer, add the default rout
 AllowedIPs = 0.0.0.0/0, ::/0
 ```
 
-Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
+<!-- markdownlint-disable code-block-style -->
+!!! warning "Change this setting only on your clients"
+    Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
+<!-- markdownlint-enable code-block-style -->
 
 That's all you need to do. You should use an online check (e.g. www.wieistmeineip.de) to check if your IP changed to the public IP address of your WireGuard server after this change up. It is possible to add this change only for a few clients, leaving the others without a full tunnel for all traffic (e.g., where this is not necessary or not desired).
 

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -1,0 +1,13 @@
+Routing your entire Internet traffic is **optional**, however, it can be advantageous in cases where you are expecting eavesdropping on the network. This may not only happen in unsecure open Wi-Fi networks (airports, hotels, trains, etc.) but also in encrypted Wi-Fi networks where the creator of the network can monitor client activity.
+
+Rerouting the Internet traffic through your Pi-hole will furthermore cause all of your Internet traffic to reach the Internet from the place where your WireGuard server is located. This can be used to obfuscate your real location as well as to be allowed to access geo-blocked content, e.g., when your Pi-hole is located in Germany but you are traveling in the United States. If you want to access a page only accessible from within Germany (like the live-broadcast of Tagesschau, etc.), this will typically not work. However, if you route your entire Internet through your Pi-hole, your network traffic will originate from Germany, allowing you to watch the content.
+
+To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your WireGuard config files:
+
+```toml
+AllowedIPs = 0.0.0.0/0, ::/0
+```
+
+Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
+
+That's all you need to do.

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -16,7 +16,7 @@ Rerouting the Internet traffic through your Pi-hole will furthermore cause all o
 
 To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your clients's WireGuard config files:
 
-```toml
+```bash
 AllowedIPs = 0.0.0.0/0, ::/0
 ```
 

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -1,6 +1,6 @@
 # Route the entire Internet traffic through the WireGuard tunnel
 
-Routing your entire Internet traffic is **optional**, however, it can be advantageous in cases where you are expecting eavesdropping on the network. This may not only happen in unsecure open Wi-Fi networks (airports, hotels, trains, etc.) but also in encrypted Wi-Fi networks where the creator of the network can monitor client activity.
+Routing your entire Internet traffic is **optional**, however, it can be advantageous in cases where you are expecting eavesdropping on the network. This may not only happen in insecure open Wi-Fi networks (airports, hotels, trains, etc.) but also in encrypted Wi-Fi networks where the creator of the network can monitor client activity.
 
 Rerouting the Internet traffic through your Pi-hole will furthermore cause all of your Internet traffic to reach the Internet from the place where your WireGuard server is located. This can be used to obfuscate your real location as well as to be allowed to access geo-blocked content, e.g., when your Pi-hole is located in Germany but you are traveling in the United States. If you want to access a page only accessible from within Germany (like the live-broadcast of Tagesschau, etc.), this will typically not work. However, if you route your entire Internet through your Pi-hole, your network traffic will originate from Germany, allowing you to watch the content.
 
@@ -25,6 +25,6 @@ AllowedIPs = 0.0.0.0/0, ::/0
     Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
 <!-- markdownlint-enable code-block-style -->
 
-That's all you need to do. You should use an online check (e.g. www.wieistmeineip.de) to check if your IP changed to the public IP address of your WireGuard server after this change up. It is possible to add this change only for a few clients, leaving the others without a full tunnel for all traffic (e.g., where this is not necessary or not desired).
+That's all you need to do. You should use an online check (e.g. www.wieistmeineip.de) to check if your IP changed to the public IP address of your WireGuard server after this change. It is possible to add this change only for a few clients, leaving the others without a full tunnel for all traffic (e.g., where this is not necessary or not desired).
 
 {!abbreviations.md!}

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -14,11 +14,28 @@ Rerouting the Internet traffic through your Pi-hole will furthermore cause all o
     The following assumes you have already prepared your Pi-hole for [IP forwarding](internal.md#enable-ip-forwarding-on-the-server) and [enabled NAT](internal.md#enable-nat-on-the-server). If this is not the case, follow the steps over there before continuing here.
 <!-- markdownlint-enable code-block-style -->
 
-To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in your clients's WireGuard config files:
+To route all traffic through the tunnel to a specific peer, add the default route (`0.0.0.0/0` for IPv4 and `::/0`for IPv6) to `AllowedIPs` in the `[Peer]` section of your clients's WireGuard config files:
 
-```bash
+``` plain
 AllowedIPs = 0.0.0.0/0, ::/0
 ```
+
+??? info "Exemplary client config file with this change"
+    ``` plain
+    [Interface]
+    PrivateKey = [your client's private key]
+    Address = [Wireguard-internal IPs of your client, e.g. 10.100.0.2/32, fd08:4711::2/128]
+    DNS = 10.100.0.1
+
+    [Peer]
+    AllowedIPs = 0.0.0.0/0, ::/0
+    Endpoint = [your server's public IP or domain]:47111
+    PublicKey = [public key of the server]
+    PresharedKey = [pre-shared key of this client]
+    PersistentKeepalive = 25
+    ```
+
+    The important change is setting the `[Peer] -> AllowedIPs` entry to `0.0.0.0/0, ::/0`
 
 <!-- markdownlint-disable code-block-style -->
 !!! warning "Change this setting only on your clients"

--- a/docs/guides/wireguard/route-everything.md
+++ b/docs/guides/wireguard/route-everything.md
@@ -20,6 +20,7 @@ To route all traffic through the tunnel to a specific peer, add the default rout
 AllowedIPs = 0.0.0.0/0, ::/0
 ```
 
+<!-- markdownlint-disable code-block-style -->
 ??? info "Exemplary client config file with this change"
     ``` plain
     [Interface]
@@ -37,7 +38,6 @@ AllowedIPs = 0.0.0.0/0, ::/0
 
     The important change is setting the `[Peer] -> AllowedIPs` entry to `0.0.0.0/0, ::/0`
 
-<!-- markdownlint-disable code-block-style -->
 !!! warning "Change this setting only on your clients"
     Do **not** set this on the server in the `[Interface]` section. WireGuard will automatically take care of setting up [correct routing](https://www.wireguard.com/netns/#routing-all-your-traffic) so that networking still functions on all your clients.
 <!-- markdownlint-enable code-block-style -->

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -4,7 +4,7 @@
 !!! info "The terms "server" and "client""
     Usage of the terms `server` and `client` were purposefully chosen in this guide specifically to help both new users and existing OpenVPN users become familiar with the construction of WireGuard's configuration files.
 
-    WireGuard documentation simply refers to both of these concepts as `peers`.
+    WireGuard itself simply refers to all connected devices as `peers`. It consitutes a connection between computers.
 <!-- markdownlint-enable code-block-style -->
 
 ## Installing the server components
@@ -82,20 +82,25 @@ systemctl daemon-reload
 systemctl start wg-quick@wg0
 ```
 
-If successful, you should not see any output. In case you get an error like
+If successful, you should not see any output.
 
-``` plain
-RTNETLINK answers: Operation not supported
-Unable to access interface: Protocol not supported
-```
+<!-- markdownlint-disable code-block-style -->
+??? warning "Error: RTNETLINK answers: Operation not supported"
+    In case you get an error like
 
-you should check that the WireGuard kernel module is loaded with the command below:
+    ``` plain
+    RTNETLINK answers: Operation not supported
+    Unable to access interface: Protocol not supported
+    ```
 
-```bash
-sudo modprobe wireguard
-```
+    you should check that the WireGuard kernel module is loaded with the command below:
 
-If you get an error saying the module is missing, try reinstalling WireGuard or restart your server and try again. This may happen when the WireGuard server is installed for a more recent kernel than you are currently running. This typically happens when you have neither updated nor restarted your system for a long time.
+    ```bash
+    sudo modprobe wireguard
+    ```
+
+    If you get an error saying the module is missing, try reinstalling WireGuard or restart your server and try again. This may happen when the WireGuard server is installed for a more recent kernel than you are currently running. This typically happens when you have neither updated nor restarted your system for a long time.
+<!-- markdownlint-enable code-block-style -->
 
 ## Check everything is running
 
@@ -104,6 +109,21 @@ With the following command, you can check if your `wireguard` server is running:
 ``` bash
 wg
 ```
+
+The output should look like the following:
+
+``` plain
+interface: wg0
+  public key: XYZ123456ABC=   ⬅ Your public key will be different
+  private key: (hidden)
+  listening port: 44711
+```
+
+Your public key will be different to ours. This is expected (you just created your own key above).
+
+## Set your Pi-hole to listen on all interfaces
+
+On your [Settings page (tab DNS)](http://pi.hole/admin/settings.php?tab=dns), ensure you set the listing mode of your Pi-hole to one of the `Listen of all interfaces` settings. The top one is perferred as it adds a bit of additional safety. Your WireGuard peers/clients will be correctly recognized as being only one hop away.
 
 You can now continue to add clients.
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -117,7 +117,7 @@ and put the following into it:
 
 ``` toml
 [Interface]
-Address = 10.100.0.1/24
+Address = 10.100.0.1/24, fd08:4711::1/64
 ListenPort = 47111
 ```
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -1,0 +1,110 @@
+# Installing the WireGuard server
+
+<!-- markdownlint-disable code-block-style -->
+!!! info "The terms "server" and "client""
+    Usage of the terms `server` and `client` were purposefully chosen in this guide specifically to help both new users and existing OpenVPN users become familiar with the construction of WireGuard's configuration files.
+
+    WireGuard documentation simply refers to both of these concepts as `peers`.
+<!-- markdownlint-enable code-block-style -->
+
+## Installing the server components
+
+Installing everything we will need for a `wireguard` connections is as simple as running:
+
+``` bash
+sudo apt-get install wireguard wireguard-tools wireguard-dkms
+```
+
+For Ubuntu 18.04 and lower, you need to do some extra steps:
+
+``` bash
+sudo add-apt-repository ppa:wireguard/wireguard
+sudo apt update
+sudo apt install wireguard wireguard-tools wireguard-dkms
+```
+
+## Initial configuration
+
+Each network interface has a private key and a list of peers. Each peer has a public key. Public keys are short and simple, and are used by peers to authenticate each other. They can be passed around for use in configuration files by any out-of-band method, similar to how one might send their SSH public key to a friend for access to a shell server.
+
+First, we create the folder containing our `wireguard` configuration:
+
+``` bash
+sudo -i
+cd /etc/wireguard
+umask 077
+```
+
+### Key generation
+
+Inhere, we generate a key-pair for the server:
+
+``` bash
+wg genkey | tee server.key | wg pubkey > server.pub
+```
+
+### Creating the WireGuard configuration
+
+Create a config file
+
+``` bash
+sudo nano /etc/wireguard/wg0.conf
+```
+
+and put the following into it:
+
+``` toml
+[Interface]
+Address = 10.100.0.1/24
+ListenPort = 44711
+SaveConfig = true
+```
+
+Then run
+
+``` bash
+echo "PrivateKey = $(cat server.key)" >> /etc/wireguard/wg0.conf
+```
+
+to copy the server's private key into your config file.
+
+## Forward port
+
+If the server is behind NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `44711/UDP`) from the router to the WireGuard server.
+
+## Start the server
+
+Register your server `wg0` as:
+
+``` bash
+systemctl enable wg-quick@wg0.service
+systemctl daemon-reload
+systemctl start wg-quick@wg0
+```
+
+If successful, you should not see any output. In case you get an error like
+
+``` plain
+RTNETLINK answers: Operation not supported
+Unable to access interface: Protocol not supported
+```
+
+you should check that the WireGuard kernel module is loaded with the command below:
+
+```bash
+sudo modprobe wireguard
+```
+
+If you get an error saying the module is missing, try reinstalling WireGuard or restart your server and try again. This may happen when the WireGuard server is installed for a more recent kernel than you are currently running. This typically happens when you have neither updated nor restarted your system for a long time.
+
+## Check everything is running
+
+With the following command, you can check if your `wireguard` server is running:
+
+``` bash
+wg
+```
+
+You can now continue to add clients.
+
+{!abbreviations.md!}

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -4,7 +4,7 @@
 !!! info "The terms "server" and "client""
     Usage of the terms `server` and `client` were purposefully chosen in this guide specifically to help both new users and existing OpenVPN users become familiar with the construction of WireGuard's configuration files.
 
-    WireGuard itself simply refers to all connected devices as `peers`. It consitutes a connection between computers.
+    WireGuard itself simply refers to all connected devices as `peers`. It constitutes a connection between computers.
 <!-- markdownlint-enable code-block-style -->
 
 ## Installing the server components
@@ -181,11 +181,11 @@ interface: wg0
   listening port: 47111
 ```
 
-Your public key will be different to ours. This is expected (you just created your own key above).
+Your public key will be different from ours. This is expected (you just created your own key above).
 
 ## Set your Pi-hole to listen on all interfaces
 
-On your [Settings page (tab DNS)](http://pi.hole/admin/settings.php?tab=dns), ensure you set the listing mode of your Pi-hole to one of the `Listen of all interfaces` settings. The top one is perferred as it adds a bit of additional safety. Your WireGuard peers/clients will be correctly recognized as being only one hop away.
+On your [Settings page (tab DNS)](http://pi.hole/admin/settings.php?tab=dns), ensure you set the listing mode of your Pi-hole to one of the `Listen of all interfaces` settings. The top one is preferred as it adds a bit of additional safety. Your WireGuard peers/clients will be correctly recognized as being only one hop away.
 
 You can now continue to add clients.
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -56,7 +56,7 @@ and put the following into it:
 ``` toml
 [Interface]
 Address = 10.100.0.1/24
-ListenPort = 44711
+ListenPort = 47111
 SaveConfig = true
 ```
 
@@ -70,7 +70,7 @@ to copy the server's private key into your config file.
 
 ## Forward port
 
-If the server is behind NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `44711/UDP`) from the router to the WireGuard server.
+If the server is behind NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `47111/UDP`) from the router to the WireGuard server.
 
 ## Start the server
 
@@ -116,7 +116,7 @@ The output should look like the following:
 interface: wg0
   public key: XYZ123456ABC=   ⬅ Your public key will be different
   private key: (hidden)
-  listening port: 44711
+  listening port: 47111
 ```
 
 Your public key will be different to ours. This is expected (you just created your own key above).

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -119,13 +119,13 @@ and put the following into it:
 [Interface]
 Address = 10.100.0.1/24
 ListenPort = 47111
-SaveConfig = true
 ```
 
 Then run
 
 ``` bash
 echo "PrivateKey = $(cat server.key)" >> /etc/wireguard/wg0.conf
+exit # Exit the sudo session
 ```
 
 to copy the server's private key into your config file.
@@ -139,9 +139,9 @@ If the server is behind NAT, be sure to forward the specified port on which Wire
 Register your server `wg0` as:
 
 ``` bash
-systemctl enable wg-quick@wg0.service
-systemctl daemon-reload
-systemctl start wg-quick@wg0
+sudo systemctl enable wg-quick@wg0.service
+sudo systemctl daemon-reload
+sudo systemctl start wg-quick@wg0
 ```
 
 If successful, you should not see any output.
@@ -169,7 +169,7 @@ If successful, you should not see any output.
 With the following command, you can check if your `wireguard` server is running:
 
 ``` bash
-wg
+sudo wg
 ```
 
 The output should look like the following:

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -26,27 +26,60 @@ sudo apt install wireguard wireguard-tools wireguard-dkms
 If there is no `wireguard` package available for your system, you can follow the instructions below to compile WireGuard from source.
 
 <!-- markdownlint-disable code-block-style -->
-???+ info "Compile WireGuard from source"
+??? info "Compile WireGuard from source"
 
-    With the following commands, you can install WireGuard from source
+    With the following commands, you can install WireGuard from source as a backport of the WireGuard kernel module for Linux to 3.10 ≤ kernel ≤ 5.5 as an out-of-tree module. More recent kernels already include WireGuard themselves and you only need to install the `wireguard` tools.
+
+    ### Update your local system
 
     ``` bash
     sudo apt update && sudo apt upgrade -y
-    sudo apt install raspberrypi-kernel-headers libmnl-dev libelf-dev build-essential git -y
-    git clone https://git.zx2c4.com/WireGuard
-    cd WireGuard/src
-    sudo make
-    sudo make install
     ```
 
-    With these commands, you can update your locally compiled WireGuard at any time:
+    ### Install the toolchain
+
+    === "Raspberry Pi"
+
+        ``` bash
+        sudo apt install -y raspberrypi-kernel-headers libelf-dev build-essential pkg-config git
+        ```
+
+    === "Linux"
+
+        ``` bash
+        sudo apt install -y linux-headers-$(uname -r) libelf-dev build-essential libmnl-dev git
+        ```
+
+    ## Download and compile the `wireguard` module
 
     ``` bash
-    cd WireGuard/
-    git pull
-    cd src
-    sudo make
-    sudo make install
+    git clone https://git.zx2c4.com/wireguard-linux-compat
+    make -C wireguard-linux-compat/src -j$(nproc)
+    sudo make -C wireguard-linux-compat/src install
+    ```
+
+    You can ignore messages like
+
+    ``` plain
+    Warning: modules_install: missing 'System.map' file. Skipping depmod.
+    ```
+
+    !!! info "Check the module installation was successful"
+
+        Run
+
+        ``` bash
+        sudo modprobe wireguard
+        ```
+
+        If there is no output, `wireguard` was loaded correctly. Note that it may be necessary to re-install the `wireguard` module when you update your system's kernel.
+
+    ## Download and compile the `wireguard` tools (`wg`, etc.)
+
+    ``` bash
+    git clone https://git.zx2c4.com/wireguard-tools
+    make -C wireguard-tools/src -j$(nproc)
+    sudo make -C wireguard-tools/src install
     ```
 
     The ZX2C4 git repository is the official source for `wireguard-linux`, see [WireGuard#Repositories](https://www.wireguard.com/repositories/) (external link)

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -115,7 +115,7 @@ sudo nano /etc/wireguard/wg0.conf
 
 and put the following into it:
 
-```toml
+```bash
 [Interface]
 Address = 10.100.0.1/24, fd08:4711::1/64
 ListenPort = 47111

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -11,13 +11,13 @@
 
 Installing everything we will need for a `wireguard` connections is as simple as running:
 
-``` bash
+```bash
 sudo apt-get install wireguard wireguard-tools wireguard-dkms
 ```
 
 For Ubuntu 18.04 and lower, you need to do some extra steps:
 
-``` bash
+```bash
 sudo add-apt-repository ppa:wireguard/wireguard
 sudo apt update
 sudo apt install wireguard wireguard-tools wireguard-dkms
@@ -32,7 +32,7 @@ If there is no `wireguard` package available for your system, you can follow the
 
     ### Update your local system
 
-    ``` bash
+    ```bash
     sudo apt update && sudo apt upgrade -y
     ```
 
@@ -40,19 +40,19 @@ If there is no `wireguard` package available for your system, you can follow the
 
     === "Raspberry Pi"
 
-        ``` bash
+        ```bash
         sudo apt install -y raspberrypi-kernel-headers libelf-dev build-essential pkg-config git
         ```
 
     === "Linux"
 
-        ``` bash
+        ```bash
         sudo apt install -y linux-headers-$(uname -r) libelf-dev build-essential libmnl-dev git
         ```
 
     ## Download and compile the `wireguard` module
 
-    ``` bash
+    ```bash
     git clone https://git.zx2c4.com/wireguard-linux-compat
     make -C wireguard-linux-compat/src -j$(nproc)
     sudo make -C wireguard-linux-compat/src install
@@ -60,7 +60,7 @@ If there is no `wireguard` package available for your system, you can follow the
 
     You can ignore messages like
 
-    ``` plain
+    ```plain
     Warning: modules_install: missing 'System.map' file. Skipping depmod.
     ```
 
@@ -68,7 +68,7 @@ If there is no `wireguard` package available for your system, you can follow the
 
         Run
 
-        ``` bash
+        ```bash
         sudo modprobe wireguard
         ```
 
@@ -76,7 +76,7 @@ If there is no `wireguard` package available for your system, you can follow the
 
     ## Download and compile the `wireguard` tools (`wg`, etc.)
 
-    ``` bash
+    ```bash
     git clone https://git.zx2c4.com/wireguard-tools
     make -C wireguard-tools/src -j$(nproc)
     sudo make -C wireguard-tools/src install
@@ -91,7 +91,7 @@ Each network interface has a private key and a list of peers. Each peer has a pu
 
 First, we create the folder containing our `wireguard` configuration:
 
-``` bash
+```bash
 sudo -i
 cd /etc/wireguard
 umask 077
@@ -101,7 +101,7 @@ umask 077
 
 Inhere, we generate a key-pair for the server:
 
-``` bash
+```bash
 wg genkey | tee server.key | wg pubkey > server.pub
 ```
 
@@ -109,13 +109,13 @@ wg genkey | tee server.key | wg pubkey > server.pub
 
 Create a config file
 
-``` bash
+```bash
 sudo nano /etc/wireguard/wg0.conf
 ```
 
 and put the following into it:
 
-``` toml
+```toml
 [Interface]
 Address = 10.100.0.1/24, fd08:4711::1/64
 ListenPort = 47111
@@ -123,7 +123,7 @@ ListenPort = 47111
 
 Then run
 
-``` bash
+```bash
 echo "PrivateKey = $(cat server.key)" >> /etc/wireguard/wg0.conf
 exit # Exit the sudo session
 ```
@@ -138,7 +138,7 @@ If the server is behind NAT, be sure to forward the specified port on which Wire
 
 Register your server `wg0` as:
 
-``` bash
+```bash
 sudo systemctl enable wg-quick@wg0.service
 sudo systemctl daemon-reload
 sudo systemctl start wg-quick@wg0
@@ -150,7 +150,7 @@ If successful, you should not see any output.
 ??? warning "Error: RTNETLINK answers: Operation not supported"
     In case you get an error like
 
-    ``` plain
+    ```plain
     RTNETLINK answers: Operation not supported
     Unable to access interface: Protocol not supported
     ```
@@ -168,13 +168,13 @@ If successful, you should not see any output.
 
 With the following command, you can check if your `wireguard` server is running:
 
-``` bash
+```bash
 sudo wg
 ```
 
 The output should look like the following:
 
-``` plain
+```plain
 interface: wg0
   public key: XYZ123456ABC=   ⬅ Your public key will be different
   private key: (hidden)

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -23,6 +23,35 @@ sudo apt update
 sudo apt install wireguard wireguard-tools wireguard-dkms
 ```
 
+If there is no `wireguard` package available for your system, you can follow the instructions below to compile WireGuard from source.
+
+<!-- markdownlint-disable code-block-style -->
+???+ info "Compile WireGuard from source"
+
+    With the following commands, you can install WireGuard from source
+
+    ``` bash
+    sudo apt update && sudo apt upgrade -y
+    sudo apt install raspberrypi-kernel-headers libmnl-dev libelf-dev build-essential git -y
+    git clone https://git.zx2c4.com/WireGuard
+    cd WireGuard/src
+    sudo make
+    sudo make install
+    ```
+
+    With these commands, you can update your locally compiled WireGuard at any time:
+
+    ``` bash
+    cd WireGuard/
+    git pull
+    cd src
+    sudo make
+    sudo make install
+    ```
+
+    The ZX2C4 git repository is the official source for `wireguard-linux`, see [WireGuard#Repositories](https://www.wireguard.com/repositories/) (external link)
+<!-- markdownlint-enable code-block-style -->
+
 ## Initial configuration
 
 Each network interface has a private key and a list of peers. Each peer has a public key. Public keys are short and simple, and are used by peers to authenticate each other. They can be passed around for use in configuration files by any out-of-band method, similar to how one might send their SSH public key to a friend for access to a shell server.

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -130,13 +130,44 @@ exit # Exit the sudo session
 
 to copy the server's private key into your config file.
 
-## Forward port
+## Forward port on your router
 
 If the server is behind a device, e.g., a router that is doing NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `47111/UDP`) from the router to the WireGuard server.
 
 ??? info "NAT: Network address translation"
     Network address translation modifies network packages. Incoming connection requests have their destination address rewritten to a different one.
     NAT involves more than just changing the IP addresses. For instance, when mapping address `1.2.3.4` to `5.6.7.8`, there is no need to add a rule to do the reverse translation. A `netfilter` system called `conntrack` recognizes packets that are replies to an existing connection. Each connection has its own NAT state attached to it. Reverse translation is done automatically.
+
+## Set up a domain name for your router
+
+When connecting from outside your network, you'll need to know the public IP address of your router to connect. However, as most households are getting dynamically-assigned public IP addresses (these addresses change periodically), you need to note down the address every day before leaving the house. Since this is obviously *very* uncomfortable, we strongly suggest registering a *dynamic host record* (often called "[DynDNS](https://en.wikipedia.org/wiki/Dynamic_DNS)" record).
+
+There are many excellent guide and a lot of services offer this for free (with more or less comfort). We suggest a few providers below, however, this list is neither absolute nor exhaustive:
+
+<!-- markdownlint-disable code-block-style -->
+??? info "DynDNS providers"
+    - [Strato.de](https://www.strato.de/hosting/dynamic-dns-free/) (Guides: [EN](https://www.strato.com/faq/en_us/domain/this-is-how-easy-it-is-to-set-up-dyndns-for-your-domains/) / [DE](https://www.strato.de/faq/domains/so-einfach-richten-sie-dyndns-fuer-ihre-domains-ein/))
+
+        If you already have a hosting package at Strato, you can easily set up a subdomain to be used as DynDNS record. This is entirely free for members.
+
+    - [DNSHome.de](DNSHome.de)
+
+        This provider offers you several free subdomains under different domain names. SSL and also IPv6 are possible. DNSSEC is activated by default. They offer configuration guides for the Fritz!Box and also `ddclient` (update tool for Windows and Linux) on the website.
+
+    - [GoIP.de](http://www.goip.de/)
+
+        Go IP is a German DynDNS provider. The service is completely free and allows the registration of one domain and up to 15 subdomains per person. The website is characterized by extensive help with setting up the router.
+
+    - [noip.com](https://www.noip.com/support/knowledgebase/getting-started-with-no-ip-com/)
+
+        You can up to three hostnames like `myname.no-ip.org` for free. A disadvantage is that you have to confirm the domains at least every 30 days, otherwise they will be deleted.
+
+    - [Dyn.com](https://account.dyn.com/)
+
+        One of the first providers to offer DynDNS was the American company Dyn, whose product "DynDNS" gave its name to an entire service branch. In the meantime, numerous successors whose services are often free of charge came up. DynDNS service is especially easy to use is if it is directly supported by the router.
+<!-- markdownlint-enable code-block-style -->
+
+You can either use the methods the corresponding providers recommend or use existing DynDNS solutions inbuilt in your router (if available). Most providers are compatible with, e.g., the popular Fritz!Box routers ([EN](https://en.avm.de/service/fritzbox/fritzbox-4040/knowledge-base/publication/show/30_Setting-up-dynamic-DNS-in-the-FRITZ-Box/) / [DE](https://avm.de/service/fritzbox/fritzbox-7590/wissensdatenbank/publication/show/30_Dynamic-DNS-in-FRITZ-Box-einrichten/)).
 
 ## Start the server
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -132,7 +132,11 @@ to copy the server's private key into your config file.
 
 ## Forward port
 
-If the server is behind NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `47111/UDP`) from the router to the WireGuard server.
+If the server is behind a device, e.g., a router that is doing NAT, be sure to forward the specified port on which WireGuard will be running (for this example, `47111/UDP`) from the router to the WireGuard server.
+
+??? info "NAT: Network address translation"
+    Network address translation modifies network packages. Incoming connection requests have their destination address rewritten to a different one.
+    NAT involves more than just changing the IP addresses. For instance, when mapping address `1.2.3.4` to `5.6.7.8`, there is no need to add a rule to do the reverse translation. A `netfilter` system called `conntrack` recognizes packets that are replies to an existing connection. Each connection has its own NAT state attached to it. Reverse translation is done automatically.
 
 ## Start the server
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -150,11 +150,11 @@ There are many excellent guide and a lot of services offer this for free (with m
 
         If you already have a hosting package at Strato, you can easily set up a subdomain to be used as DynDNS record. This is entirely free for members.
 
-    - [DNSHome.de](DNSHome.de)
+    - [DNSHome.de](https://DNSHome.de)
 
         This provider offers you several free subdomains under different domain names. SSL and also IPv6 are possible. DNSSEC is activated by default. They offer configuration guides for the Fritz!Box and also `ddclient` (update tool for Windows and Linux) on the website.
 
-    - [GoIP.de](http://www.goip.de/)
+    - [GoIP.de](https://www.goip.de/)
 
         Go IP is a German DynDNS provider. The service is completely free and allows the registration of one domain and up to 15 subdomains per person. The website is characterized by extensive help with setting up the router.
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -136,19 +136,21 @@ If the server is behind a device, e.g., a router that is doing NAT, be sure to f
 
 ??? info "NAT: Network address translation"
     Network address translation modifies network packages. Incoming connection requests have their destination address rewritten to a different one.
-    NAT involves more than just changing the IP addresses. For instance, when mapping address `1.2.3.4` to `5.6.7.8`, there is no need to add a rule to do the reverse translation. A `netfilter` system called `conntrack` recognizes packets that are replies to an existing connection. Each connection has its own NAT state attached to it. Reverse translation is done automatically.
+    NAT involves more than just changing the IP addresses. For instance, when mapping address `1.2.3.4` to `5.6.7.8`, there is no need to add a rule to do the reverse translation. A `netfilter` system called `conntrack` recognizes packets that are replies to an existing connection. Each connection has its own NAT state attached to it. The reverse translation is done automatically.
 
 ## Set up a domain name for your router
 
-When connecting from outside your network, you'll need to know the public IP address of your router to connect. However, as most households are getting dynamically-assigned public IP addresses (these addresses change periodically), you need to note down the address every day before leaving the house. Since this is obviously *very* uncomfortable, we strongly suggest registering a *dynamic host record* (often called "[DynDNS](https://en.wikipedia.org/wiki/Dynamic_DNS)" record).
+When connecting from outside your network, you'll need to know the public IP address of your router to connect. However, as most households are getting dynamically-assigned public IP addresses (these addresses change periodically), you need to note down the address every day before leaving the house. Since this is *very* uncomfortable, we strongly suggest registering a *dynamic host record* (often called "[DynDNS](https://en.wikipedia.org/wiki/Dynamic_DNS)" record).
 
-There are many excellent guide and a lot of services offer this for free (with more or less comfort). We suggest a few providers below, however, this list is neither absolute nor exhaustive:
+The public IP address is checked at regular intervals. As soon as it changes, the router (or a DynDNS tool) sends a corresponding message to a URL of the service provider, who then updates the record.
+
+There are many excellent guides and a lot of services offer this for free (with more or less comfort). We suggest a few providers below, however, this list is neither absolute nor exhaustive:
 
 <!-- markdownlint-disable code-block-style -->
 ??? info "DynDNS providers"
     - [Strato.de](https://www.strato.de/hosting/dynamic-dns-free/) (Guides: [EN](https://www.strato.com/faq/en_us/domain/this-is-how-easy-it-is-to-set-up-dyndns-for-your-domains/) / [DE](https://www.strato.de/faq/domains/so-einfach-richten-sie-dyndns-fuer-ihre-domains-ein/))
 
-        If you already have a hosting package at Strato, you can easily set up a subdomain to be used as DynDNS record. This is entirely free for members.
+        If you already have a hosting package at Strato, you can easily set up a subdomain to be used as a DynDNS record. This is entirely free for members.
 
     - [DNSHome.de](https://DNSHome.de)
 

--- a/docs/guides/wireguard/server.md
+++ b/docs/guides/wireguard/server.md
@@ -109,13 +109,13 @@ wg genkey | tee server.key | wg pubkey > server.pub
 
 Create a config file
 
-```bash
+``` bash
 sudo nano /etc/wireguard/wg0.conf
 ```
 
 and put the following into it:
 
-```bash
+``` plain
 [Interface]
 Address = 10.100.0.1/24, fd08:4711::1/64
 ListenPort = 47111
@@ -123,7 +123,7 @@ ListenPort = 47111
 
 Then run
 
-```bash
+``` bash
 echo "PrivateKey = $(cat server.key)" >> /etc/wireguard/wg0.conf
 exit # Exit the sudo session
 ```
@@ -138,7 +138,7 @@ If the server is behind NAT, be sure to forward the specified port on which Wire
 
 Register your server `wg0` as:
 
-```bash
+``` bash
 sudo systemctl enable wg-quick@wg0.service
 sudo systemctl daemon-reload
 sudo systemctl start wg-quick@wg0
@@ -150,31 +150,41 @@ If successful, you should not see any output.
 ??? warning "Error: RTNETLINK answers: Operation not supported"
     In case you get an error like
 
-    ```plain
+    ``` plain
     RTNETLINK answers: Operation not supported
     Unable to access interface: Protocol not supported
     ```
 
     you should check that the WireGuard kernel module is loaded with the command below:
 
-    ```bash
+    ``` bash
     sudo modprobe wireguard
     ```
 
     If you get an error saying the module is missing, try reinstalling WireGuard or restart your server and try again. This may happen when the WireGuard server is installed for a more recent kernel than you are currently running. This typically happens when you have neither updated nor restarted your system for a long time.
+
+??? warning "Error: RTNETLINK answers: File exists"
+    In case you get an error like
+
+    ``` plain
+    RTNETLINK answers: File exists
+    ```
+
+    you need to check the configured IP addresses (check the CIDR notation). Overlapping IP address ranges cause this error when trying to register a router for an address where a a route already exists. This is meaningful and always an error in your configuration. However, the error message could be more clear about this.
+
 <!-- markdownlint-enable code-block-style -->
 
 ## Check everything is running
 
 With the following command, you can check if your `wireguard` server is running:
 
-```bash
+``` bash
 sudo wg
 ```
 
 The output should look like the following:
 
-```plain
+``` plain
 interface: wg0
   public key: XYZ123456ABC=   ⬅ Your public key will be different
   private key: (hidden)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,15 @@ nav:
     - 'Configuring Caddy for Pi-hole': guides/caddy-configuration.md
     - 'Configuring Traefik for Pi-hole (not in Docker)': guides/traefik-configuration-nodocker.md
     - 'Benchmarking': guides/benchmark.md
+    - 'Remote accessing Pi-hole using WireGuard':
+      - 'Overview': guides/wireguard/overview.md
+      - 'Concept': guides/wireguard/concept.md
+      - 'Install server': guides/wireguard/server.md
+      - 'Add client(s)': guides/wireguard/client.md
+      - 'Optional extra features':
+        - 'Make all local devices accessible': guides/wireguard/internal.md
+        - 'Reroute all Internet traffic': guides/wireguard/route-everything.md
+      - 'Troubleshooting': guides/wireguard/faq.md
     - 'Pi-hole and OpenVPN Server':
       - 'Overview': guides/vpn/overview.md
       - 'Installation': guides/vpn/installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ markdown_extensions:
   - pymdownx.extra
   # (https://facelessuser.github.io/pymdown-extensions/extensions/details/)
   - pymdownx.details
+  # Tabbed provides a syntax to easily add tabbed Markdown content.
+  # https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/
+  - pymdownx.tabbed
   # Adds syntax for defining footnotes in Markdown documents (https://python-markdown.github.io/extensions/footnotes/)
   - footnotes
   # Adds the ability to define abbreviations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,14 +95,14 @@ nav:
     - 'How to sign-off commits': guides/github/how-to-signoff.md
   - 'Guides':
     - 'Pi-hole as All-Around DNS Solution': guides/unbound.md
-    - 'Remote access using WireGuard':
+    - 'WireGuard VPN':
       - 'Overview': guides/wireguard/overview.md
       - 'Concept': guides/wireguard/concept.md
       - 'Install server': guides/wireguard/server.md
       - 'Add client(s)': guides/wireguard/client.md
       - 'Optional extra features':
-        - 'Make all local devices accessible': guides/wireguard/internal.md
-        - 'Reroute all Internet traffic': guides/wireguard/route-everything.md
+        - 'Make local devices accessible': guides/wireguard/internal.md
+        - 'Tunnel all Internet traffic': guides/wireguard/route-everything.md
       - 'Troubleshooting': guides/wireguard/faq.md
     - 'Configuring DNS-Over-HTTPS on Pi-hole': guides/dns-over-https.md
     - 'Upstream DNS Providers': guides/upstream-dns-providers.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,14 +92,7 @@ nav:
     - 'How to sign-off commits': guides/github/how-to-signoff.md
   - 'Guides':
     - 'Pi-hole as All-Around DNS Solution': guides/unbound.md
-    - 'Configuring DNS-Over-HTTPS on Pi-hole': guides/dns-over-https.md
-    - 'Upstream DNS Providers': guides/upstream-dns-providers.md
-    - 'Editing Whitelist and Blacklist': guides/whitelist-blacklist.md
-    - 'Configuring NGINX for Pi-hole': guides/nginx-configuration.md
-    - 'Configuring Caddy for Pi-hole': guides/caddy-configuration.md
-    - 'Configuring Traefik for Pi-hole (not in Docker)': guides/traefik-configuration-nodocker.md
-    - 'Benchmarking': guides/benchmark.md
-    - 'Remote accessing Pi-hole using WireGuard':
+    - 'Remote access using WireGuard':
       - 'Overview': guides/wireguard/overview.md
       - 'Concept': guides/wireguard/concept.md
       - 'Install server': guides/wireguard/server.md
@@ -108,6 +101,13 @@ nav:
         - 'Make all local devices accessible': guides/wireguard/internal.md
         - 'Reroute all Internet traffic': guides/wireguard/route-everything.md
       - 'Troubleshooting': guides/wireguard/faq.md
+    - 'Configuring DNS-Over-HTTPS on Pi-hole': guides/dns-over-https.md
+    - 'Upstream DNS Providers': guides/upstream-dns-providers.md
+    - 'Editing Whitelist and Blacklist': guides/whitelist-blacklist.md
+    - 'Configuring NGINX for Pi-hole': guides/nginx-configuration.md
+    - 'Configuring Caddy for Pi-hole': guides/caddy-configuration.md
+    - 'Configuring Traefik for Pi-hole (not in Docker)': guides/traefik-configuration-nodocker.md
+    - 'Benchmarking': guides/benchmark.md
     - 'Pi-hole and OpenVPN Server':
       - 'Overview': guides/vpn/overview.md
       - 'Installation': guides/vpn/installation.md


### PR DESCRIPTION
### This adds a guide how to install WireGuard on your Pi-hole.

You may ask: Why another guide when there are already quite a few on the web?

The answer is manifold:

1. The vast majority of online guides only sets up an IPv4 tunnel. **The Pi-hole guide gives you IPv4 and IPv6 through the same tunnel.**
2. This guide is **build around a DNS server being in the center of the tunnel**. This ensures the settings are fine-tuned so no DNS leakage happens.
3. Some guides show you how to make your internal network clients available through the tunnel, sometimes, they tell you how to route your entire traffic over the Internet. **In our guide, we show you all the options and you decide exactly what you want**. Everything in one place means a similar writing style and expectation on what you did before. This makes it easier for you to set things up.
4. The guide has been written to include **support for old kernels** for which you have to compile the kernel module yourself. No searching around on the web for instructions. Everything is already there.
5. **Concerning security, the Pi-hole WireGuard guide pulls all the stops** while still being very simple to set up. This starts in explaining how to generate safe keys and does not stop at using an additional layer of security by using simple per-connection pre-shared keys (PSK).