### PR TITLE
Update unbound.md

### DIFF
--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -62,8 +62,7 @@ If you are installing unbound from a package manager, it should install the `roo
 **Optional**: Download the current root hints file (the list of primary root servers which are serving the domain "." - the root domain). Update it roughly every six months. Note that this file changes infrequently. This is only necessary if you are not installing unbound from a package manager. If you do this optional step, you will need to uncomment the `root-hints:` configuration line in the suggested config file.
 
 ```bash
-wget -O root.hints https://www.internic.net/domain/named.root
-sudo mv root.hints /var/lib/unbound/
+sudo wget https://www.internic.net/domain/named.root -O /var/lib/unbound/root.hints
 ```
 
 ### Configure `unbound`

--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -62,7 +62,7 @@ If you are installing unbound from a package manager, it should install the `roo
 **Optional**: Download the current root hints file (the list of primary root servers which are serving the domain "." - the root domain). Update it roughly every six months. Note that this file changes infrequently. This is only necessary if you are not installing unbound from a package manager. If you do this optional step, you will need to uncomment the `root-hints:` configuration line in the suggested config file.
 
 ```bash
-sudo wget https://www.internic.net/domain/named.root -O /var/lib/unbound/root.hints
+wget https://www.internic.net/domain/named.root -qO- | sudo tee /var/lib/unbound/root.hints
 ```
 
 ### Configure `unbound`


### PR DESCRIPTION
`/var/lib/unbound/root.hints` gets stored with `pi` user ownership:

```
pi@ph5:~ $ stat /var/lib/unbound/root.hints
[..]
Access: (0644/-rw-r--r--)  Uid: ( 1000/      pi)   Gid: ( 1000/      pi)
```

This adjustment will write it as the `root `user:

```
pi@ph5:~ $ stat /var/lib/unbound/root.hints
[..]
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
```