### PR TITLE
Fix spelling mistake noticed after an invalid hacktoberfest PR

### DIFF
--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -163,7 +163,7 @@ Finally, configure Pi-hole to use your recursive DNS server by specifying `127.0
 ### Add logging to unbound
 
 !!! warning
-    It's not recommonded to increase verbosity for daily use, as unbound logs a lot. But it might be helpful for debugging purposes.
+    It's not recommended to increase verbosity for daily use, as unbound logs a lot. But it might be helpful for debugging purposes.
 
 There are five levels of verbosity
 


### PR DESCRIPTION
That's all this does. Self-applied invalid label, but still needs a merge