### PR TITLE
Syntax highlighting in unbound config

### DIFF
--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -76,7 +76,7 @@ Highlights:
 
 `/etc/unbound/unbound.conf.d/pi-hole.conf`:
 
-```ini
+```yaml
 server:
     # If no logfile is specified, syslog is used
     # logfile: "/var/log/unbound/unbound.log"
@@ -179,7 +179,7 @@ Level 5 logs client identification for cache misses
 First, specify the log file and the verbosity level in the `server` part of
 `/etc/unbound/unbound.conf.d/pi-hole.conf`:
 
-```ini
+```yaml
 server:
     # If no logfile is specified, syslog is used
     logfile: "/var/log/unbound/unbound.log"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
This PR fixes syntax highlighting of unbound configuration. Currently both configuration blocks look like commented out. 

https://docs.pi-hole.net/guides/unbound/#configure-unbound:
<img width="816" alt="Zrzut ekranu 2020-10-16 o 18 08 07" src="https://user-images.githubusercontent.com/1526000/96282900-9bbc5e80-0fdb-11eb-9ebe-4062db671926.png">
https://docs.pi-hole.net/guides/unbound/#add-logging-to-unbound:
<img width="806" alt="Zrzut ekranu 2020-10-16 o 18 08 27" src="https://user-images.githubusercontent.com/1526000/96282906-9ced8b80-0fdb-11eb-9064-8ef0d31ecb84.png">

**How does this PR accomplish the above?:**
Unbound configuration seems to be a YAML file. I'm changing code block language from `ini` to `yaml`. 
<img width="777" alt="Zrzut ekranu 2020-10-16 o 18 08 49" src="https://user-images.githubusercontent.com/1526000/96283303-4b91cc00-0fdc-11eb-9343-d850d2c3d95c.png">
<img width="777" alt="Zrzut ekranu 2020-10-16 o 18 08 38" src="https://user-images.githubusercontent.com/1526000/96283308-4d5b8f80-0fdc-11eb-96b7-db253f0baf23.png">



**What documentation changes (if any) are needed to support this PR?:**
\-
