### PR TITLE
Disable `resolvconf` for `unbound` (optional)

### DIFF
--- a/docs/guides/unbound.md
+++ b/docs/guides/unbound.md
@@ -160,6 +160,42 @@ Finally, configure Pi-hole to use your recursive DNS server by specifying `127.0
 
 (don't forget to hit Return or click on `Save`)
 
+### Disable `resolvconf` for `unbound` (optional)
+
+The `unbound` package can come with a systemd service called `unbound-resolvconf.service` and default enabled.
+It instructs `resolvconf` to write `unbound`'s own DNS service at `nameserver 127.0.0.1` , but without the 5335 port, into the file `/etc/resolv.conf`.
+That `/etc/resolv.conf` file is used by local services/processes to determine DNS servers configured.
+If you configured `/etc/dhcpcd.conf` with a `static domain_name_servers=` line, these DNS server(s) will be ignored/overruled by this service.
+
+To check if this service is enabled for your distribution, run below one and take note of the the `Active` line.
+It will show either `active` or `inactive` or it might not even be installed resulting in a `could not be found` message:
+
+```bash
+sudo systemctl status unbound-resolvconf.service
+```
+
+To disable the service if so desire, run below two:
+
+```bash
+sudo systemctl disable unbound-resolvconf.service
+```
+
+```bash
+sudo systemctl stop unbound-resolvconf.service
+```
+
+To have the `domain_name_servers=` in the file `/etc/dhcpcd.conf` activated/propagate, run below one:
+
+```bash
+sudo systemctl restart dhcpcd
+```
+
+And check with below one if IP(s) on the `nameserver` line(s) reflects the ones in the `/etc/dhcpcd.conf` file:
+
+```bash
+cat /etc/resolv.conf
+```
+
 ### Add logging to unbound
 
 !!! warning


### PR DESCRIPTION
The `unbound` package can come with a systemd service called `unbound-resolvconf.service` and default enabled (Pi-OS Buster at least).
It instructs `resolvconf` to write `unbound`'s own DNS service at `nameserver 127.0.0.1` , but without the 5335 port, into the file `/etc/resolv.conf`.

These added instructions allow one to use the DNS servers configured in `dhcpcd.conf` instead of the one pushed by the `unbound-resolvconf` service.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X ] I have made only one major change in my proposed changes.
- [X ] I have commented my proposed changes within the code.
- [X ] I have tested my proposed changes, and have included unit tests where possible.
- [X ] I am willing to help maintain this change if there are issues with it later.
- [X ] I give this submission freely and claim no ownership.
- [X ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*


**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*


**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
