### PR TITLE
removed script extension (.sh) for the cron files

### DIFF
--- a/docs/guides/dns/cloudflared.md
+++ b/docs/guides/dns/cloudflared.md
@@ -232,11 +232,11 @@ sudo systemctl restart cloudflared
 #### Automating Cloudflared Updates
 
 If you want to have the system update `cloudflared` automatically, simply place the update commands for your configuration method in the
-file `/etc/cron.weekly/cloudflared-updater.sh`, and adjust permissions:
+file `/etc/cron.weekly/cloudflared-updater`, and adjust permissions:
 
 ```bash
-sudo chmod +x /etc/cron.weekly/cloudflared-updater.sh
-sudo chown root:root /etc/cron.weekly/cloudflared-updater.sh
+sudo chmod +x /etc/cron.weekly/cloudflared-updater
+sudo chown root:root /etc/cron.weekly/cloudflared-updater
 ```
 
 The system will now attempt to update the cloudflared binary automatically, once per week.


### PR DESCRIPTION
The cron.weekly scripts are started by run-parts which skips all files with extension.
https://serverfault.com/questions/408093/why-does-cron-weekly-not-run

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
*not applicable for the documentation update*
- [ ] I have tested my proposed changes, and have included unit tests where possible.
*not applicable for the documentation update*
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*Fix the issue in the documentation. Cron doesn't run scripts with extension in file name (https://serverfault.com/questions/408093/why-does-cron-weekly-not-run)*


**How does this PR accomplish the above?:**
*Documentation is updated to propose using file name without extension for the cron task `/etc/cron.weekly/cloudflared-updater.sh -> /etc/cron.weekly/cloudflared-updater`*



**What documentation changes (if any) are needed to support this PR?:**
*the changes are in the documentation*

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
