### PR TITLE
Recommend to use nettle 3.7.2

### DIFF
--- a/docs/ftldns/compile.md
+++ b/docs/ftldns/compile.md
@@ -23,9 +23,9 @@ sudo dnf install gcc gmp-devel gmp-static m4 cmake libidn-devel readline-devel x
 Compile and install a recent version using:
 
 ```bash
-wget https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz
-tar -xzf nettle-3.6.tar.gz
-cd nettle-3.6
+wget https://ftp.gnu.org/gnu/nettle/nettle-3.7.2.tar.gz
+tar -xzf nettle-3.7.2.tar.gz
+cd nettle-3.7.2
 ./configure --libdir=/usr/local/lib
 make -j $(nproc)
 sudo make install


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

From the `nettle-3.7.2` CHANGELOG:

	This is a bugfix release, fixing a bug in ECDSA signature
	verification that could lead to a denial of service attack
	(via an assertion failure) or possibly incorrect results. It
	also fixes a few related problems where scalars are required
	to be canonically reduced modulo the ECC group order, but in
	fact may be slightly larger.

	>>> Upgrading to the new version is strongly recommended. <<<

	Even when no assert is triggered in ecdsa_verify, ECC point
	multiplication may get invalid intermediate values as input,
	and produce incorrect results. It's trivial to construct
	alleged signatures that result in invalid intermediate values.
	It appears difficult to construct an alleged signature that
	makes the function misbehave in such a way that an invalid
	signature is accepted as valid, but such attacks can't be
	ruled out without further analysis.

FTL compiled without any issues against this new version of `nettle`.