### PR TITLE
Add scroll-up and dark mode to documentation

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,8 +1,3 @@
-body,
-input {
-    color: #000;
-}
-
 .md-nav {
     font-size: 14px;
     line-height: 1.4;
@@ -16,9 +11,17 @@ input {
 .md-typeset code,
 .md-typeset pre {
     white-space: pre-wrap;
-    color: #532ba8;
+    color: var(--code-color);
 }
 
 .text-center {
     text-align: center !important;
+}
+
+[data-md-color-scheme="default"] {
+    --code-color: #532ba8;
+}
+
+[data-md-color-scheme="slate"] {
+    --code-color: #a47df8;
 }

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -18,10 +18,20 @@
     text-align: center !important;
 }
 
+.md-typeset table:not([class]) th {
+    color: var(--table-foreground);
+    background-color: var(--table-background);
+}
+
 [data-md-color-scheme="default"] {
     --code-color: #532ba8;
+    --table-foreground: var(--md-default-bg-color); /* table header backgrounds */
+    --table-background: var(--md-default-fg-color--light); /* table header (text) */
 }
 
 [data-md-color-scheme="slate"] {
     --code-color: #a47df8;
+    --md-typeset-a-color: #7c90ff; /* links */
+    --table-foreground: #a3acdf; /* table header (text) */
+    --table-background: #272e53; /* table header backgrounds */
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: 'Pi-hole documentation'
 site_url: 'https://docs.pi-hole.net/'
 repo_url: 'https://github.com/pi-hole/pi-hole'
 edit_uri: '../docs/blob/master/docs/'
-copyright: 'Copyright &copy; 2020 Pi-hole LLC'
+copyright: 'Copyright &copy; 2021 Pi-hole LLC'
 remote_branch: gh-pages
 theme:
   name: 'material'
@@ -17,6 +17,25 @@ theme:
     code: 'Roboto Mono'
   features:
     - navigation.top
+  palette:
+
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to dark mode
+
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/lightbulb
+        name: Switch to light mode
 
 markdown_extensions:
   # Code highlighting in ``` ``` blocks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
   font:
     text: 'Source Sans Pro'
     code: 'Roboto Mono'
+  features:
+    - navigation.top
 
 markdown_extensions:
   # Code highlighting in ``` ``` blocks


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

- Show back-to-top button when the user, after scrolling down, starts to scroll up again. It's rendered in the lower right corner of the view port.
  ![Screenshot_2021-04-03 Overview of Pi-hole - Pi-hole documentation](https://user-images.githubusercontent.com/16748619/113476644-0f183680-947d-11eb-8ee2-0160e3d50bb9.png)

- Add dark mode switch (check out the lightbulb in the header)
  ![Screenshot_2021-04-03 Configuration - Pi-hole documentation](https://user-images.githubusercontent.com/16748619/113476657-1b03f880-947d-11eb-8ba6-8a17b3592cdb.png)
  ![Screenshot_2021-04-03 Configuration - Pi-hole documentation(1)](https://user-images.githubusercontent.com/16748619/113476655-19d2cb80-947d-11eb-9bf2-4d1f53d37f75.png)

For proper color support we need CSS variables, however, I think they are safe to use concerning [browser support](https://caniuse.com/css-variables) (we don't want to support IE IIRC).