### PR TITLE
Use https for URLs in docs and guides

### DIFF
--- a/docs/docker/DHCP.md
+++ b/docs/docker/DHCP.md
@@ -31,7 +31,7 @@ Possibly the simplest way to get DHCP working with Docker Pi-hole is to use [hos
 
 A [Macvlan network](https://docs.docker.com/network/macvlan/) is the most advanced option since it requires more network knowledge and setup. This mode is similar to host network mode but instead of borrowing the IP of your docker host computer it grabs a new IP address off your LAN network.
 
-Having the container get its own IP not only solves the broadcast problem but avoids port conflicts you might have on devices such as NAS devices with web interfaces. Tony Lawrence detailed macvlan setup for Pi-hole first in the second part of his great blog series about [Running Pi-hole on Synology Docker](http://tonylawrence.com/posts/unix/synology/running-pihole-inside-docker/), check it out here: [Free your Synology ports with Macvlan](http://tonylawrence.com/posts/unix/synology/free-your-synology-ports/)
+Having the container get its own IP not only solves the broadcast problem but avoids port conflicts you might have on devices such as NAS devices with web interfaces. Tony Lawrence detailed macvlan setup for Pi-hole first in the second part of his great blog series about [Running Pi-hole on Synology Docker](https://tonylawrence.com/posts/unix/synology/running-pihole-inside-docker/), check it out here: [Free your Synology ports with Macvlan](https://tonylawrence.com/posts/unix/synology/free-your-synology-ports/)
 
 ### Docker Pi-hole with a bridge networking
 
@@ -41,7 +41,7 @@ If you want to use docker's bridged network mode then you need to run a DHCP rel
 
 Although uncommon, if your router is an advanced enough router it may support a DHCP relay. Try googling for your router manufacturer + DHCP relay or looking in your router's configuration around the DHCP settings or advanced areas.
 
-If your router doesn't support it, you can run a software/container based DHCP relay on your LAN instead. The author of dnsmasq made a very tiny simple one called [DHCP-helper](http://thekelleys.org.uk/dhcp-helper/READ-ME). [DerFetzer](https://discourse.pi-hole.net/t/dhcp-with-docker-compose-and-bridge-networking/17038) kindly shared his great setup of a DHCP-helper container on the Pi-hole Discourse forums.
+If your router doesn't support it, you can run a software/container based DHCP relay on your LAN instead. The author of dnsmasq made a very tiny simple one called [DHCP-helper](https://thekelleys.org.uk/dhcp-helper/READ-ME). [DerFetzer](https://discourse.pi-hole.net/t/dhcp-with-docker-compose-and-bridge-networking/17038) kindly shared his great setup of a DHCP-helper container on the Pi-hole Discourse forums.
 
 ### Warning about the Default bridge network
 

--- a/docs/guides/vpn/openvpn/client.ovpn
+++ b/docs/guides/vpn/openvpn/client.ovpn
@@ -53,7 +53,7 @@ key /home/dl6er/openvpn/client.key
 # certificate has the correct key usage set.
 # This is an important precaution to protect against
 # a potential attack discussed here:
-#  http://openvpn.net/howto.html#mitm
+#  https://openvpn.net/howto.html#mitm
 remote-cert-tls server
 
 # If a tls-auth key is used on the server

--- a/docs/main/origins.md
+++ b/docs/main/origins.md
@@ -6,7 +6,7 @@ last_updated: Sun Jan 13 18:35:14 2019 UTC
 
 Pi-hole being a **advertising-aware DNS/Web server**, makes use of the following technologies:
 
-- [`dnsmasq`](http://www.thekelleys.org.uk/dnsmasq/doc.html) - a lightweight DNS and DHCP server
+- [`dnsmasq`](https://www.thekelleys.org.uk/dnsmasq/doc.html) - a lightweight DNS and DHCP server
 - [`curl`](https://curl.haxx.se/) - A command-line tool for transferring data with URL syntax
 - [`lighttpd`](https://www.lighttpd.net/) - web server designed and optimized for high performance
 - [`php`](https://www.php.net/) - a popular general-purpose web scripting language


### PR DESCRIPTION
Signed-off-by: David Beitey <david@davidjb.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Improve security in external links mentioned in documentation and guides.

**How does this PR accomplish the above?:**

Updates `http://` URLs to use `https://`; each URL has been tested and loads appropriately.

**What documentation changes (if any) are needed to support this PR?:**

None that I'm aware of; the links are the same, just more secure.
