### PR TITLE
Change note to warning in FritzBox Guide

### DIFF
--- a/docs/routers/fritzbox-de.md
+++ b/docs/routers/fritzbox-de.md
@@ -34,7 +34,7 @@ eingetragen werden.
 ![Screenshot der Fritz!Box DHCP Einstellungen](../images/fritzbox-dhcp-de.png)
 
 !!! warning
-Clients bemerken Änderungen an den DHCP Einstellungen erst, wenn der DHCP Lease erneuert wird. Der einfachste Weg dies zu erzwingen ist ein Unterbrechen und Wiederherstellen der Netzwerkverbindung.
+    Clients bemerken Änderungen an den DHCP Einstellungen erst, wenn der DHCP Lease erneuert wird. Der einfachste Weg dies zu erzwingen ist ein Unterbrechen und Wiederherstellen der Netzwerkverbindung.
 
 Nun sollten einzelne Clients in Pi-hole Dashboard auftrauchen.
 

--- a/docs/routers/fritzbox.md
+++ b/docs/routers/fritzbox.md
@@ -32,7 +32,7 @@ Home Network/Network/Network Settings/IP Adresses/IPv4 Configuration/Home Networ
 ![Screenshot of Fritz!Box DHCP Settings](../images/fritzbox-dhcp.png)
 
 !!! warning
-Clients will notice changes in DHCP settings only after they acquired a new DHCP lease. The easiest way to force a renewal is to dis/reconnect the client from the network.
+    Clients will notice changes in DHCP settings only after they acquired a new DHCP lease. The easiest way to force a renewal is to dis/reconnect the client from the network.
 
 Now you should see individual clients in Pi-hole's web dashboard.
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Changes the note in the FritzBox router guides about the need of disconnection the clients from the network to obtain new DHCP settings to a warning. 


Before:

![Bildschirmfoto zu 2021-10-23 14-19-36](https://user-images.githubusercontent.com/26622301/138555839-64c8b643-93b2-44e2-8769-ac7ba917a6ff.png)



After:
![Bildschirmfoto zu 2021-10-23 14-27-30](https://user-images.githubusercontent.com/26622301/138556059-49d011a8-b484-4b66-bdcf-c9e905ca54ab.png)