### PR TITLE
Fix wireguard guide

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -84,7 +84,6 @@ After a restart, the server file should look like:
 [Interface]
 Address = 10.100.0.1/24, fd08::1/128
 ListenPort = 47111
-SaveConfig = true
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 
 [Peer]


### PR DESCRIPTION
Removed the server config line "SaveConfig = true". This one does only
appear in the add client section.


- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Adding the the config line `SaveConfig=true` enables WireGuard to save the configuration of an interface on exit.
The problem is that if you are following the guide, restarting WireGuard overwrites your config changes.

Another point is that this line only exists in the guide for adding a client and not for setting up the server.

According to some forum and reddit threads this is a problem.

**How does this PR accomplish the above?:**
Remove the offending line


**What documentation changes (if any) are needed to support this PR?:**
None of which I know
