### PR TITLE
Add script for automated Wireguard client generation

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -12,6 +12,8 @@ For each new client, the following steps must be taken. For the sake of simplici
     #!/bin/bash
     ipv4="$1$4"
     ipv6="$2$4"
+    serv4="${1}1"
+    serv6="${2}1"
     target="$3"
     name="$5"
 
@@ -33,7 +35,8 @@ For each new client, the following steps must be taken. For the sake of simplici
     echo "PublicKey = $(cat server.pub)" >> "${name}.conf"
     echo "PresharedKey = $(cat "${name}.psk")" >> "${name}.conf"
     echo "Endpoint = $target" >> "${name}.conf"
-    echo "AllowedIPs = ${1}0/24, ${3}/64" >> "${name}.conf"
+    echo "AllowedIPs = ${serv4}/32, ${serv6}/128" >> "${name}.conf" # clients isolated from one another
+    # echo "AllowedIPs = ${1}0/24, ${2}/64" >> "${name}.conf" # clients can see each other
     echo "PersistentKeepalive = 25" >> "${name}.conf"
 
     # Print QR code scanable by the Wireguard mobile app on screen
@@ -160,7 +163,7 @@ Next, add your server as peer for this client:
 
 ```plain
 [Peer]
-AllowedIPs = 10.100.0.0/24, fd08::/64
+AllowedIPs = 10.100.0.1/32, fd08::1/128
 Endpoint = [your public IP or domain]:47111
 PersistentKeepalive = 25
 ```


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/FTL/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 

## 10

---

The existing "all commands you need to run" box is replaced by a proper script that makes adding new Wireguard clients easier than it ever was (a single line you have to run). Tested on two independent servers and with Android and Linux clients.

In addition, this fixes a few shortcomings I discovered only today: the existing hints are not sufficient and can cause frustration because clients cannot connect.