### PR TITLE
Fix ugly 'pihole' styling

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -3,6 +3,10 @@
     line-height: 1.4;
 }
 
+.md-nav__link {
+    display: inline-flex;
+}
+
 .md-typeset {
     font-size: .7rem;
     line-height: 1.5;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
     - 'Updating': main/update.md
     - 'Uninstalling': main/uninstall.md
   - 'Pi-hole Core':
-    - 'The <samp>pihole</samp> command': core/pihole-command.md
+    - 'The &nbsp<samp>pihole</samp>&nbsp command': core/pihole-command.md
   - 'Databases':
     - 'Overview': database/index.md
     - 'Query database': database/ftl.md


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Fixes the styling of `pihole` in the sidebar.

Before:
![Image Pasted at 2021-11-24 20-44](https://user-images.githubusercontent.com/26622301/143679564-0bc4b94f-290c-48e6-8659-76f758619c02.jpg)

After:
![Bildschirmfoto zu 2021-11-27 12-36-35](https://user-images.githubusercontent.com/26622301/143679553-cec87853-20d5-4ab4-835d-8afaffb20d7d.png)

How?

Material for MKDocs automatically sets `display` to `flex` for `.md-nav__link`

https://github.com/squidfunk/mkdocs-material/blob/05440550509097f81cec8274c461fe29b0c12a95/src/assets/stylesheets/main/layout/_nav.scss#L98

This does not play well with the `<samp>` we use here to emphasize `pihole`. Changing it to `inline-flex` works better, but need two `&nbsp` to get some space around the `<samp>`