### PR TITLE
Include configuration for Debian Bullseye NAT

### DIFF
--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -44,6 +44,22 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
     Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `ens2p0` or similar on more recent Ubuntu versions (check, e.g., `ip a` for details about your local interfaces).
 <!-- markdownlint-enable code-block-style -->
 
+<!-- markdownlint-disable code-block-style -->
+!!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
+    Debian Bullseye doesn't include iptables per default and uses nftables. The iptables commands can be easily implemented since the package will automatically translate and import them to nftables. First you need to install iptables:
+    ```bash
+    apt install iptables
+    ```
+
+    After that you have to set following rules for PostUP and PostDown:
+    ```bash
+    PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+    PostDown = nft flush ruleset
+    ```
+
+    **Be careful with the PostDown command since it will flush all rules!** 
+<!-- markdownlint-enable code-block-style -->
+
 `PostUp` and `PostDown` defines steps to be run after the interface is turned on or off, respectively. In this case, iptables is used to set Linux IP masquerade rules to allow all the clients to share the server’s IPv4 and IPv6 address.
 The rules will then be cleared once the tunnel is down.
 

--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -48,7 +48,7 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 !!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
     Debian Bullseye doesn't include iptables per default and uses nftables. The iptables commands can be easily implemented since the package will automatically translate and import them to nftables. First you need to install iptables:
     ```bash
-    apt install iptables
+    sudo apt install iptables
     ```
 
     After that you have to set following rules for PostUP and PostDown:

--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -48,7 +48,7 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 !!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
     Debian Bullseye doesn't include iptables per default and uses nftables.
 
-    After that you have to set following rules for PostUP and PostDown:
+    We have to set following rules for PostUP and PostDown:
     ```bash
     PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade
     PostDown = nft delete table ip wireguard; nft delete table ip6 wireguard

--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -46,18 +46,13 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 
 <!-- markdownlint-disable code-block-style -->
 !!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
-    Debian Bullseye doesn't include iptables per default and uses nftables. The iptables commands can be easily implemented since the package will automatically translate and import them to nftables. First you need to install iptables:
-    ```bash
-    sudo apt install iptables
-    ```
+    Debian Bullseye doesn't include iptables per default and uses nftables.
 
     After that you have to set following rules for PostUP and PostDown:
     ```bash
-    PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-    PostDown = nft flush ruleset
+    PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade
+    PostDown = nft delete table ip wireguard; nft delete table ip6 wireguard
     ```
-
-    **Be careful with the PostDown command since it will flush all rules!** 
 <!-- markdownlint-enable code-block-style -->
 
 `PostUp` and `PostDown` defines steps to be run after the interface is turned on or off, respectively. In this case, iptables is used to set Linux IP masquerade rules to allow all the clients to share the server’s IPv4 and IPv6 address.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Debian 11/Raspian 11 doesn't inlcude iptables per default, so for the NAT we need to install it. It translates automatically the commands to nftables. Only the PostDown command doesn't work on iptables base. Maybe there is another way to remove the exact line from nftables. The configuration is tested on a fresh raspian 11.

**How does this PR accomplish the above?:**
Installing iptables, modifing configuration

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
