### PR TITLE
Update suggested EDNS buffer size to 1232

### DIFF
--- a/docs/ftldns/dnsmasq_warn.md
+++ b/docs/ftldns/dnsmasq_warn.md
@@ -130,10 +130,10 @@ Warnings commonly seen in `dnsmasq`'s log file (`/var/log/pihole.log`) and the P
     You can get rid of the warning by adding a config file like `/etc/dnsmasq.d/99-edns.conf` and adding
 
     ``` plain
-    edns-packet-max=1280
+    edns-packet-max=1232
     ```
 
-    After running `pihole restartdns` your Pi-hole will not even try larger packet sizes (the default is 4096).
+    After running `pihole restartdns` your Pi-hole will not even try larger packet sizes (the default is 4096). Check out our [unbound guide](../guides/dns/unbound.md) for a comment about the particular value of `1232`.
 
 !!! warning "Ignoring query from non-local network"
 

--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -111,9 +111,9 @@ server:
     # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
     use-caps-for-id: no
 
-    # Reduce EDNS reassembly buffer size.
-    # Suggested by the unbound man page to reduce fragmentation reassembly problems
-    edns-buffer-size: 1472
+    # DNS Flag Day 2020 recommends a message size of 1232 bytes to avoid IP
+    # fragmentation while minimizaing the use of TCP
+    edns-buffer-size: 1232
 
     # Perform prefetching of close to expired message cache entries
     # This only applies to domains that have been frequently queried

--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -111,8 +111,21 @@ server:
     # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
     use-caps-for-id: no
 
-    # DNS Flag Day 2020 recommends a message size of 1232 bytes to avoid IP
-    # fragmentation while minimizaing the use of TCP
+    # Reduce EDNS reassembly buffer size.
+    # IP fragmentation is unreliable on the Internet today, and can cause
+    # transmission failures when large DNS messages are sent via UDP. Even
+    # when fragmentation does work, it may not be secure; it is theoretically
+    # possible to spoof parts of a fragmented DNS message, without easy
+    # detection at the receiving end. Recently, there was an excellent study
+    # >>> Defragmenting DNS - Determining the optimal maximum UDP response size for DNS <<<
+    # by Axel Koolhaas, and Tjeerd Slokker (https://indico.dns-oarc.net/event/36/contributions/776/)
+    # in collaboration with NLnet Labs explored DNS using real world data from the
+    # the RIPE Atlas probes and the researchers suggested different values for
+    # IPv4 and IPv6 and in different scenarios. They advise that servers should
+    # be configured to limit DNS messages sent over UDP to a size that will not
+    # trigger fragmentation on typical network links. DNS servers can switch
+    # from UDP to TCP when a DNS response is too big to fit in this limited
+    # buffer size. This value has also been suggested in DNS Flag Day 2020.
     edns-buffer-size: 1232
 
     # Perform prefetching of close to expired message cache entries
@@ -142,6 +155,14 @@ dig pi-hole.net @127.0.0.1 -p 5335
 ```
 
 The first query may be quite slow, but subsequent queries, also to other domains under the same TLD, should be fairly quick.
+
+You should also consider adding
+
+``` plain
+edns-packet-max=1232
+```
+
+to a config file like `/etc/dnsmasq.d/99-edns.conf` to signal FTL to adhere to this limit.
 
 ### Test validation
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---

**What does this PR aim to accomplish?:**

Update suggested EDNS buffer size to 1232 as recommended on DNS Flag Day 2020. There is more reasoning given in the `unbound` config comment added within this PR.