### PR TITLE
Add dns-port to telnet documentation

### DIFF
--- a/docs/ftldns/telnet-api.md
+++ b/docs/ftldns/telnet-api.md
@@ -155,4 +155,12 @@ Connect via e.g. `telnet 127.0.0.1 4711` or use `echo ">command" | nc 127.0.0.1 
     cache-inserted: 15529
     ```
 
+- `>dns-port`: Get DNS port FTL is listening on
+
+    ```text
+    53
+    ```
+
+Note that the port can also be `0` if someone decides to disable the DNS server part of Pi-hole
+
 {!abbreviations.md!}


### PR DESCRIPTION
---
**What does this PR aim to accomplish?:**
Documents the new `dns-port` telnet API endpoint added in https://github.com/pi-hole/FTL/pull/1264

