### PR TITLE
Add note how to add comments to pihole-FTL.conf

### DIFF
--- a/docs/ftldns/configfile.md
+++ b/docs/ftldns/configfile.md
@@ -1,6 +1,6 @@
 You can create a file `/etc/pihole/pihole-FTL.conf` that will be read by *FTL*DNS on startup.
 
-Note: comments need to start with `#;`
+Note: comments need to start with `#;` to avoid issues with PHP and `bash` reading this file. (See [https://github.com/pi-hole/pi-hole/pull/4081](https://github.com/pi-hole/pi-hole/pull/4081)  for more details)
 
 Possible settings (**the option shown first is the default**):
 

--- a/docs/ftldns/configfile.md
+++ b/docs/ftldns/configfile.md
@@ -1,5 +1,7 @@
 You can create a file `/etc/pihole/pihole-FTL.conf` that will be read by *FTL*DNS on startup.
 
+Note: comments need to start with `#;`
+
 Possible settings (**the option shown first is the default**):
 
 ---


### PR DESCRIPTION
**What does this PR aim to accomplish?:**
Adds a note on the comment syntax of pihole-FTL.conf

See this discussion: https://github.com/pi-hole/pi-hole/pull/4081

