### PR TITLE
Add deprecation note to IP blocking mode

### DIFF
--- a/docs/ftldns/blockingmode.md
+++ b/docs/ftldns/blockingmode.md
@@ -39,7 +39,7 @@ Following [RFC 3513, Internet Protocol Version 6 (IPv6) Addressing Architecture,
 ## Pi-hole's IP (IPv6 NODATA) blocking
 
 !!! warning
-    Consider this option deprecated. The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option will be removed in the future.
+    The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option may be removed in the future.
 
 `/etc/pihole/pihole-FTL.conf` setting:
 
@@ -70,7 +70,7 @@ doubleclick.net.        2       IN      A       192.168.2.11
 ## Pi-hole's full IP blocking
 
 !!! warning
-    Consider this option deprecated. The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option will be removed in the future.
+    The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option may be removed in the future.
 
 `/etc/pihole/pihole-FTL.conf` setting:
 

--- a/docs/ftldns/blockingmode.md
+++ b/docs/ftldns/blockingmode.md
@@ -38,6 +38,9 @@ Following [RFC 3513, Internet Protocol Version 6 (IPv6) Addressing Architecture,
 
 ## Pi-hole's IP (IPv6 NODATA) blocking
 
+!!! warning
+    Consider this option deprecated. The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option will be removed in the future.
+
 `/etc/pihole/pihole-FTL.conf` setting:
 
 ```
@@ -65,6 +68,9 @@ doubleclick.net.        2       IN      A       192.168.2.11
 - May cause time-outs for HTTPS content even with properly configured firewall rules
 
 ## Pi-hole's full IP blocking
+
+!!! warning
+    Consider this option deprecated. The block page can only be displayed for unencrypted `http` connections. Since the majority of web pages today are accessed over encrypted `https` connections, no block page will be displayed. This option will be removed in the future.
 
 `/etc/pihole/pihole-FTL.conf` setting:
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Add deprecation note to the IP blocking modes. The blocking page is not accessible via `https` web pages - which are the majority of pages on the internet today (except if you have a MTM setup). Those options should be considered deprecated as they will be removed in a future Pi-hole version.