### PR TITLE
Fix Inconsistency of IPv6 Addresses

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -112,7 +112,7 @@ After a restart, the server file should look like:
 
 ```plain
 [Interface]
-Address = 10.100.0.1/24, fd08::1/128
+Address = 10.100.0.1/24, fd08:4711::1/128
 ListenPort = 47111
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 
@@ -140,7 +140,7 @@ interface: wg0
 
 peer: F+80gbmHVlOrU+es13S18oMEX2g=   ⬅ Your peer's public key will be different
   preshared key: (hidden)
-  allowed ips: 10.100.0.2/32, fd08::2/128
+  allowed ips: 10.100.0.2/32, fd08:4711::2/128
 ```
 
 ## Create client configuration
@@ -163,7 +163,7 @@ Next, add your server as peer for this client:
 
 ```plain
 [Peer]
-AllowedIPs = 10.100.0.1/32, fd08::1/128
+AllowedIPs = 10.100.0.1/32, fd08:4711::1/128
 Endpoint = [your public IP or domain]:47111
 PersistentKeepalive = 25
 ```

--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -100,7 +100,7 @@ It is possible to add this only for a few clients, leaving the others isolated t
     DNS = 10.100.0.1
 
     [Peer]
-    AllowedIPs = 10.100.0.0/24, fd08::/64, 192.168.2.0/24
+    AllowedIPs = 10.100.0.0/24, fd08:4711::/64, 192.168.2.0/24
     Endpoint = [your server's public IP or domain]:47111
     PublicKey = [public key of the server]
     PresharedKey = [pre-shared key of this client]


### PR DESCRIPTION
Signed-off-by: Max Steele <max@amaxsteele.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Most of the guide for using Wireguard uses the IPv6 prefix of fd08:4711::/64, but a few places use fd08::/64. This could cause some strange behavior depending on how the server-side network is configured. At the very least, it is confusing to those who don't understand what these commands mean. I have checked and there are no related issues.


**How does this PR accomplish the above?:**
In the Wireguard VPN guide, all instances where the fd08::/64 prefix was used, have now been changed to fd08:4711::/64.


**What documentation changes (if any) are needed to support this PR?:**
N/A - This is a documentation change.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
