### PR TITLE
Upgrade mkdocs/material to fix Netlify breakages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 markdown-include==0.6.0
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkdocs-git-revision-date-localized-plugin==1.0.0
-mkdocs-material==8.2.7
+mkdocs-material==8.2.8
 mkdocs-redirects==1.0.3


### PR DESCRIPTION
See: https://github.com/mkdocs/mkdocs/issues/2799

Not sure if the bump to mkdocs 1.3.0 will cause issues - if it does we can use 1.2.4 instead