### PR TITLE
Add requirement of nftables to wireguard config

### DIFF
--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -47,7 +47,8 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 <!-- markdownlint-disable code-block-style -->
 !!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
     Debian Bullseye doesn't include iptables per default and uses nftables.
-
+	(you may need to install `nftables` using `sudo apt-get install nftables`)
+	
     We have to set following rules for PostUP and PostDown:
     ```bash
     PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 markdown-include==0.6.0
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkdocs-git-revision-date-localized-plugin==1.0.0
-mkdocs-material==8.2.7
+mkdocs-material==8.2.8
 mkdocs-redirects==1.0.3


### PR DESCRIPTION
This PR adds a command which maybe not installed on a users computer, this command installs the dependency.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

Fixing a dependency issue which will cause it not to function if nftables is not installed.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

By adding a recommendation to install it, giving the command for the user to copy


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed. :+1: 
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time. :+1: 
