### PR TITLE
Add requirement of nftables to wireguard config

### DIFF
--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -47,6 +47,7 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 <!-- markdownlint-disable code-block-style -->
 !!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
     Debian Bullseye doesn't include iptables per default and uses nftables.
+    (you may need to install `nftables` using `sudo apt-get install nftables`)
 
     We have to set following rules for PostUP and PostDown:
     ```bash


### PR DESCRIPTION
Signed-off-by: CleanMachine1 <78213164+CleanMachine1@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**

Fixing a dependency issue which will cause wireguard not to function if nftables is not installed. (I discovered this on my upgraded from buster to bullseye install by going through the journalctl logs)


**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*


**What documentation changes (if any) are needed to support this PR?:**
By adding a reference to install the potentially missing dependency 


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed. :+1: 
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time. :+1: 

Follows on from #690 where I made a mistake
