### PR TITLE
Specifying DNS Server for client config in automatic script.

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -29,6 +29,7 @@ For each new client, the following steps must be taken. For the sake of simplici
 
     echo "[Interface]" > "${name}.conf"
     echo "Address = $ipv4/32, $ipv6/128" >> "${name}.conf"
+    echo "DNS = ${serv4}, ${serv6}" >> "${name}.conf" #Specifying DNS Server
     echo "PrivateKey = $(cat "${name}.key")" >> "${name}.conf"
     echo "" >> "${name}.conf"
     echo "[Peer]" >> "${name}.conf"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix the automatic script in Wireguard DNS guide for automatically generating client configs. It does not work without specifying the DNS for obvious reasons.


**How does this PR accomplish the above?:**
Add the missing DNS. It is there in the manual steps but was missing in the script.


**What documentation changes (if any) are needed to support this PR?:**
This is a documentation change.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
