### PR TITLE
Fixing the umask operation by transferring it to the script itself.

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -10,6 +10,8 @@ For each new client, the following steps must be taken. For the sake of simplici
 
     ```bash
     #!/bin/bash
+    umask 077
+
     ipv4="$1$4"
     ipv6="$2$4"
     serv4="${1}1"
@@ -51,7 +53,6 @@ For each new client, the following steps must be taken. For the sake of simplici
     ```bash
     sudo -i
     cd /etc/wireguard
-    umask 077
 
     bash "10.100.0." "fd08:4711::" "my_server_domain:47111" 2 "annas-android"
     bash "10.100.0." "fd08:4711::" "my_server_domain:47111" 3 "peters-laptop"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
In the Pi-hole guide for [Wireguard VPN Client configuration](https://docs.pi-hole.net/guides/vpn/wireguard/client/), in the automatic script section, it says to run `umask 077` under `sudo -i` and then run the script.

This does not work, and this error is spit out along with the QR Code:
```
Warning: writing to world accessible file.
Consider setting the umask to 077 and trying again.
```

**How does this PR accomplish the above?:**
If 'umask 077' is added to the script itself, it does work and no error is spit.
This also leads to less commands for the user to copy and paste.