### PR TITLE
Fix the command to run the Wireguard client generation script

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -51,11 +51,12 @@ For each new client, the following steps must be taken. For the sake of simplici
     Run the script like
 
     ```bash
+    chmod +x /path/to/script.sh
     sudo -i
     cd /etc/wireguard
 
-    bash "10.100.0." "fd08:4711::" "my_server_domain:47111" 2 "annas-android"
-    bash "10.100.0." "fd08:4711::" "my_server_domain:47111" 3 "peters-laptop"
+    /path/to/script.sh "10.100.0." "fd08:4711::" "my_server_domain:47111" 2 "annas-android"
+    /path/to/script.sh "10.100.0." "fd08:4711::" "my_server_domain:47111" 3 "peters-laptop"
 
     exit
     ```

--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -9,7 +9,7 @@ For each new client, the following steps must be taken. For the sake of simplici
     Script content:
 
     ```bash
-    #!/bin/bash
+    #! /usr/bin/env bash
     umask 077
 
     ipv4="$1$4"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
The command to run the Wireguard client generation script is not correct.

**How does this PR accomplish the above?:**
It asks the user to give bash the path to script as the first argument.