### PR TITLE
Remove workaround link for cloudflared on arm32 devices

### DIFF
--- a/docs/guides/dns/cloudflared.md
+++ b/docs/guides/dns/cloudflared.md
@@ -46,7 +46,7 @@ sudo chmod +x /usr/local/bin/cloudflared
 cloudflared -v
 ```
 
-Note: Users [have reported](https://github.com/cloudflare/cloudflared/issues/38) that the current version of cloudflared produces a segmentation fault error on Raspberry Pi Zero W, Model 1B and 2B. As a workaround you can use an older version provided at <https://bin.equinox.io/a/4SUTAEmvqzB/cloudflared-2018.7.2-linux-arm.tar.gz> instead.
+Note: Users [have reported](https://github.com/cloudflare/cloudflared/issues/38) that the current version of cloudflared produces a segmentation fault error on Raspberry Pi Zero W, Model 1B and 2B. Currently, there is [no known workaround](https://github.com/pi-hole/docs/issues/710).
 
 #### arm64 architecture (64-bit Raspberry Pi)
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))


---
**What does this PR aim to accomplish?:**
Fixes https://github.com/pi-hole/docs/issues/710. The workaround link to older `cloudflared` version (introduced by https://github.com/pi-hole/docs/pull/475) does not exist anymore.