### PR TITLE
Adjust for icon rename in FontAwesome v6

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: 'Pi-hole documentation'
 site_url: 'https://docs.pi-hole.net/'
 repo_url: 'https://github.com/pi-hole/pi-hole'
 edit_uri: '../docs/blob/master/docs/'
-copyright: 
+copyright:
 remote_branch: gh-pages
 theme:
   name: 'material'
@@ -183,7 +183,7 @@ nav:
 
 extra:
   social:
-    - icon: fontawesome/solid/earth-americas
+    - icon: fontawesome/solid/globe-americas
       link: https://pi-hole.net/
       name: Website
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

FontAwesome v6 has renamed some icons, including `earth-americas` to `globe-americas`. https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6

We use FontAwesome since https://github.com/pi-hole/docs/pull/680 (mkdocs-material-8.1.11).

This PR adjusts the icon name we use.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[x] I have read the above and my PR is ready for review. _Check this box to confirm_
