### PR TITLE
No sudo when installing python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please make sure you fork the repo and change the clone URL in the example below
     git clone https://github.com/YOUR-USERNAME/docs
     cd docs
     sudo apt install python3-pip
-    sudo pip3 install -r requirements.txt
+    pip3 install -r requirements.txt
     ```
 
     - Running the docs server:


### PR DESCRIPTION
Changes the `README` on how to test the documentation locally with `mkdocs`. There is no need to install the python requirements system-wide with `sudo` powers