### PR TITLE
Add steps for fixing unbound on bullseye

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -183,7 +183,7 @@ Finally, configure Pi-hole to use your recursive DNS server by specifying `127.0
 
 (don't forget to hit Return or click on `Save`)
 
-### Disable `resolvconf` for `unbound` (optional)
+### Disable `resolvconf` for `unbound` (optional / recommended for Bullseye)
 
 The `unbound` package can come with a systemd service called `unbound-resolvconf.service` and default enabled.
 It instructs `resolvconf` to write `unbound`'s own DNS service at `nameserver 127.0.0.1` , but without the 5335 port, into the file `/etc/resolv.conf`.
@@ -217,6 +217,25 @@ And check with below one if IP(s) on the `nameserver` line(s) reflects the ones 
 
 ```bash
 cat /etc/resolv.conf
+```
+
+The following steps may also be necessary if `/etc/unbound/unbound.conf.d/resolvconf_resolvers.conf` is already present on the system.
+
+Edit file `/etc/resolvconf.conf` and comment out the last line which should read:
+
+```bash
+#unbound_conf=/etc/unbound/unbound.conf.d/resolvconf_resolvers.conf
+```
+
+Delete the unwanted unbound configuration file:
+
+```bash
+sudo rm /etc/unbound/unbound.conf.d/resolvconf_resolvers.conf
+```
+
+Restart unbound:
+```bash
+sudo service unbound restart
 ```
 
 ### Add logging to unbound

--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -234,6 +234,7 @@ sudo rm /etc/unbound/unbound.conf.d/resolvconf_resolvers.conf
 ```
 
 Restart unbound:
+
 ```bash
 sudo service unbound restart
 ```


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Added steps to fix unbound for Bullseye installations where `unbound-resolvconf.service` has already created `/etc/unbound/unbound.conf.d/resolvconf_resolvers.conf`


- **How does this PR accomplish the above?:**

Added steps and changed header description.


- **What documentation changes (if any) are needed to support this PR?:**

This is a doc change, so no additional changes required.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[ ] I have read the above and my PR is ready for review. _Check this box to confirm_
