### PR TITLE
Fix error in 'Advanced examples' expression

### DIFF
--- a/docs/regex/tutorial.md
+++ b/docs/regex/tutorial.md
@@ -119,7 +119,7 @@ Blocks domains containing only numbers (no letters) and ending in `.com` or `.ed
 ### Block domains without subdomains
 
 ```
-^[a-z0-9]+([\-]{1}[a-z0-9]+)*\.[a-z]{2,7}$
+^[a-z0-9]+([-]{1}[a-z0-9]+)*\.[a-z]{2,7}$
 ```
 
 A domain name shall not start or end with a dash but can contain any number of them. It must be followed by a TLD (we assume a valid TLD length of two to seven characters)


### PR DESCRIPTION
The section on character groups clearly states "To include a literal
-, make it the first or last character, ..."

In the example `Block domains without subdomains` the bounded
character group `[\-]{1}` should be `[-]{1}` if the intention is to match a
literal `-` as suggested by the accompanying description.

---

**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [X] I have read the above and my PR is ready for review. _Check this box to confirm_

closes #732 
