### PR TITLE
Remove CentOS 7 from list of supported OS

### DIFF
--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -28,7 +28,6 @@ The following operating systems are **officially** supported:
 | Ubuntu       | 18.x / 20.x / 22.x     | ARM / x86_64        |
 | Debian       | 10 /11          | ARM / x86_64 / i386 |
 | Fedora       | 34          | ARM / x86_64        |
-| CentOS       | 7                | x86_64              |
 | CentOS Stream | 8            | x86_64              |
 
 <!-- markdownlint-disable code-block-style -->


### PR DESCRIPTION
To be merged after the following PR has made it to the master branch in core:

https://github.com/pi-hole/pi-hole/pull/4828