### PR TITLE
Move downloaded cloudflared binaries instead of copying

### DIFF
--- a/docs/guides/dns/cloudflared.md
+++ b/docs/guides/dns/cloudflared.md
@@ -41,7 +41,7 @@ Here we are downloading the precompiled binary and copying it to the `/usr/local
 
 ```bash
 wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm
-sudo cp ./cloudflared-linux-arm /usr/local/bin/cloudflared
+sudo mv -f ./cloudflared-linux-arm /usr/local/bin/cloudflared
 sudo chmod +x /usr/local/bin/cloudflared
 cloudflared -v
 ```
@@ -52,7 +52,7 @@ Note: Users [have reported](https://github.com/cloudflare/cloudflared/issues/38)
 
 ```bash
 wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64
-sudo cp ./cloudflared-linux-arm64 /usr/local/bin/cloudflared
+sudo mv -f ./cloudflared-linux-arm64 /usr/local/bin/cloudflared
 sudo chmod +x /usr/local/bin/cloudflared
 cloudflared -v
 ```
@@ -211,7 +211,7 @@ If you configured `cloudflared` manually (by writing a systemd unit yourself), t
 ```bash
 wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm
 sudo systemctl stop cloudflared
-sudo cp ./cloudflared-linux-arm /usr/local/bin/cloudflared
+sudo mv -f ./cloudflared-linux-arm /usr/local/bin/cloudflared
 sudo chmod +x /usr/local/bin/cloudflared
 sudo systemctl start cloudflared
 cloudflared -v


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes: https://github.com/pi-hole/docs/issues/761

If the old binaries were not removed after downloading, the update `wget` command will append a number to the new downloaded file and the old file will be copied.


- **How does this PR accomplish the above?:**

Instead of copying, we move the file. No old files will remain for the next update

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
