### PR TITLE
`PORTFILE` is deprecated

### DIFF
--- a/docs/ftldns/configfile.md
+++ b/docs/ftldns/configfile.md
@@ -258,10 +258,6 @@ The location of FTL's log file. If you want to move the log file to a different 
 
 The file which contains the PID of FTL's main process.
 
-#### `PORTFILE=/run/pihole-FTL.port` {#file_PORTFILE data-toc-label='Port file'}
-
-The file containing the port FTL's API is listening on.
-
 #### `SOCKETFILE=/run/pihole/FTL.sock` {#file_SOCKETFILE data-toc-label='Socket file'}
 
 The file containing the socket FTL's API is listening on.
@@ -397,6 +393,12 @@ If neither `BLOCK_IPV4` nor `LOCAL_IPV4` are set, this setting is used to set bo
 *This option is deprecated and may be removed in future versions, please use `BLOCK_IPV6` and `LOCAL_IPV6` instead*
 
 If neither `BLOCK_IPV6` nor `LOCAL_IPV6` are set, this setting is used to set both of them. If either of the two is set, this setting is ignored altogether.
+
+#### `PORTFILE=/run/pihole-FTL.port` {#file_PORTFILE data-toc-label='Port file'}
+
+*This option is deprecated as FTL does not write any port file anymore. Plesase parse pihole-FTL.conf if you need to check if a custom API port is set.*
+
+The file containing the port FTL's API is listening on.
 
 
 {!abbreviations.md!}

--- a/docs/ftldns/configfile.md
+++ b/docs/ftldns/configfile.md
@@ -396,7 +396,7 @@ If neither `BLOCK_IPV6` nor `LOCAL_IPV6` are set, this setting is used to set bo
 
 #### `PORTFILE=/run/pihole-FTL.port` {#file_PORTFILE data-toc-label='Port file'}
 
-*This option is deprecated as FTL does not write any port file anymore. Plesase parse pihole-FTL.conf if you need to check if a custom API port is set.*
+*This option is deprecated as FTL does not write any port file anymore. Please parse `pihole-FTL.conf` if you need to check if a custom API port is set.*
 
 The file containing the port FTL's API is listening on.
 


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

FTL PR https://github.com/pi-hole/FTL/pull/1445 removes the `PORTFILE` config option as we read the API port now directly from `pihole-FTL.conf` in `web` and `core`. This marks the `PORTFILE` option as deprecated

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
