### PR TITLE
Drop Fedora 34 and add 35 & 36

### DIFF
--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -30,7 +30,7 @@ The following operating systems are **officially** supported:
 | Raspberry Pi OS <br>(formerly Raspbian)     | Buster / Bullseye | ARM                 |
 | Ubuntu       | 20.x / 22.x     | ARM / x86_64        |
 | Debian       | 10 /11          | ARM / x86_64 / i386 |
-| Fedora       | 34          | ARM / x86_64        |
+| Fedora       | 35/36          | ARM / x86_64        |
 | CentOS Stream | 8            | x86_64              |
 
 <!-- markdownlint-disable code-block-style -->


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Drops Fedora 34 from the list of supported OS and adds Fedora 35 and Fedora 36. 
Accompanies: https://github.com/pi-hole/pi-hole/pull/4952


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
