### PR TITLE
Fix Regex and Wildcard commands

### DIFF
--- a/docs/core/pihole-command.md
+++ b/docs/core/pihole-command.md
@@ -16,7 +16,7 @@ Pi-hole makes use of many commands, and here we will break down those required t
 | Feature | Invocation |
  -------------- | --------------
 [Core](#core-script) | `pihole`
-[Whitelisting, Blacklisting and Regex](#whitelisting-blacklisting-and-regex) | `pihole -w`, `pihole -b`, `pihole -regex`, `pihole --wild`
+[Whitelisting, Blacklisting and Regex](#whitelisting-blacklisting-and-regex) | `pihole -w`, `pihole -b`, `pihole --regex`, `pihole --wild`
 [Debugger](#debugger) | `pihole debug`
 [Log Flush](#log-flush) | `pihole flush`
 [Reconfigure](#reconfigure) | `pihole reconfigure`

--- a/docs/core/pihole-command.md
+++ b/docs/core/pihole-command.md
@@ -16,7 +16,7 @@ Pi-hole makes use of many commands, and here we will break down those required t
 | Feature | Invocation |
  -------------- | --------------
 [Core](#core-script) | `pihole`
-[Whitelisting, Blacklisting and Regex](#whitelisting-blacklisting-and-regex) | `pihole -w`, `pihole -b`, `pihole -regex`, `pihole -wild`
+[Whitelisting, Blacklisting and Regex](#whitelisting-blacklisting-and-regex) | `pihole -w`, `pihole -b`, `pihole -regex`, `pihole --wild`
 [Debugger](#debugger) | `pihole debug`
 [Log Flush](#log-flush) | `pihole flush`
 [Reconfigure](#reconfigure) | `pihole reconfigure`
@@ -48,9 +48,9 @@ The core script of Pi-hole provides the ability to tie many DNS related function
 
 | | |
  -------------- | --------------
-Help Command    | `pihole -w --help`, `pihole -b --help`, `pihole -regex --help`, `pihole -wild --help`
+Help Command    | `pihole -w --help`, `pihole -b --help`, `pihole --regex --help`, `pihole --wild --help`
 Script Location | [`/opt/pihole/list.sh`](https://github.com/pi-hole/pi-hole/blob/master/advanced/Scripts/list.sh)
-Example Usage   | [`pihole -regex '^example.com$' '.*\.example2.net'`](https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#white-black-list)
+Example Usage   | [`pihole --regex '^example.com$' '.*\.example2.net'`](https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#white-black-list)
 
 Administrators need to be able to manually add and remove domains for various purposes, and these commands serve that purpose.
 
@@ -58,7 +58,7 @@ See [Regex Blocking](../regex/overview.md) for more information about using Rege
 
 **Basic Script Process**:
 
-* Each domain is validated using regex (except when using `-regex`), to ensure invalid domains and IDNs are not added
+* Each domain is validated using regex (except when using `--regex`), to ensure invalid domains and IDNs are not added
 * A domain gets added to or removed from the `domainlist` table in [`/etc/pihole/gravity.db`](../database/gravity/index.md)
 * The DNS server is then reloaded
 


### PR DESCRIPTION
Regex and Wildcard use a double dash "--" rather than a single dash "-"

Signed-off-by: Noah Nash <48302704+noah-nash@users.noreply.github.com>

## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

The documentation page has a small syntax error. This PR fixes it


- **How does this PR accomplish the above?:**

Added in the missing dash `-` character to the relevant regex and wildcard commands


- **What documentation changes (if any) are needed to support this PR?:**

*Replace this with a detailed list of any necessary changes*


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
