### PR TITLE
use dnssec.works instead of verteiltesysteme.net in unbound documentation

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -169,8 +169,8 @@ to a config file like `/etc/dnsmasq.d/99-edns.conf` to signal FTL to adhere to t
 You can test DNSSEC validation using
 
 ```bash
-dig sigfail.verteiltesysteme.net @127.0.0.1 -p 5335
-dig sigok.verteiltesysteme.net @127.0.0.1 -p 5335
+dig fail01.dnssec.works @127.0.0.1 -p 5335
+dig dnssec.works @127.0.0.1 -p 5335
 ```
 
 The first command should give a status report of `SERVFAIL` and no IP address. The second should give `NOERROR` plus an IP address.


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Use `dnssec.works` instead of `verteiltesysteme.net` in our unbound documentation (see https://github.com/pi-hole/FTL/pull/1469#issuecomment-1307718167 for further details).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
