### PR TITLE
Fritz!Box: assign DNS real-time priority and block bypassing DNS traffic

### DIFF
--- a/docs/routers/fritzbox-de.md
+++ b/docs/routers/fritzbox-de.md
@@ -125,12 +125,14 @@ Dieser Eintrag kann dann unter
 Internet/Filter/Priorisierung -> Echtzeitanwendungen -> Neue Regel
 ```
 
-hinzugefügt werden. Da sämtliche Einstellungen über das Pi-hole gehen, wählen Sie dieses als Gerät aus, für das die Regel gelten soll. Sollten Sie sich unsicher sein, kann hier auch "`Alle Geräte`" ausgewählt werden. Unter "`Netzwerkanwendung`" wählen Sie den soeben angelegten Eintrag "`DNS`" aus.
+hinzugefügt werden. Wählen Sie nun ihr Pi-hole aus. Sollten Sie sich unsicher sein, kann hier auch "`Alle Geräte`" ausgewählt werden. Unter "`Netzwerkanwendung`" wählen Sie den soeben angelegten Eintrag "`DNS`" aus.
 
 ## Optional: DNS Anfragen nur vom Pi-hole erlauben
 
 Nach der Konfiguration des Pi-holes als DNS Server des Netzwerks ist die Einrichtung abgeschlossen. Es bleibt jedoch weiterhin das Risiko einer Umgehung des Pi-holes bestehen - Netzwerkgeräte können sich direkt mit anderen, frei verfügbaren, DNS Servers im Internet verbinden. Dies kann durch eine geeignete Fiterregel jedoch einfach verhindert werden.
 
+!!! warning
+    Einige Geräte oder Programme nutzen fest hinterlegte DNS Server und funktionieren ggfs. nicht mehr ordnungsgemäß falls sie diesen DNS Server nicht erreichen können. Fall solch ein Verhalten auftritt, können Sie dieses Gerät von der Filterregel ausnehmen ausnehmen.
 Insofern nicht bereits vorhanden, legen Sie unter
 
 ``` plain
@@ -143,7 +145,7 @@ zwei Zugangsprofile an (z.B. "`Standard`" und "`Unbeschränkt`"). Im Profil "`St
 Erweiterte Einstellungen -> Gesperrte Netzwerkanwendungen
 ```
 
-die oben angelegte Netzwerkanwendung "`DNS`" hinzu.
+die wie unter `Optional: Erhöhung der Priorität von DNS Anfragen` beschrieben angelegte Netzwerkanwendung "`DNS`" hinzu.
 Im Profil "`Unbeschränkt`" darf "`DNS`" *nicht* als gesperrt hinterlegt werden.
 
 Nun werden die Zugangsprofile unter

--- a/docs/routers/fritzbox-de.md
+++ b/docs/routers/fritzbox-de.md
@@ -15,7 +15,7 @@ Einige dieser Einstellungen sind nur sichtbar, wenn vorher die Ansicht auf "Erwe
 Mit dieser Konfiguration wird allen Clients die IP des Pi-hole als DNS Server angeboten, wenn sie einen DHCP Lease von der Fritz!Box anfordern.
 DNS Anfragen nehmen folgenden Weg
 
-```bash
+``` plain
 Client -> Pi-hole -> Upstream DNS Server
 ```
 
@@ -25,7 +25,7 @@ Client -> Pi-hole -> Upstream DNS Server
 
 Um diese Konfiguration zu nutzen, muss die IP des Pi-hole als "Lokaler DNS-Server" in
 
-```bash
+``` plain
 Heimnetz/Netzwerk/Netzwerkeinstellungen/IP-Adressen/IPv4-Konfiguration/Heimnetz
 ```
 
@@ -42,13 +42,13 @@ Nun sollten einzelne Clients im Pi-hole Dashboard auftauchen.
 
 Mit dieser Konfiguration wird Pi-hole  auch von der Fritz!Box selbst als Upstream DNS Server genutzt. DNS Anfragen nehmen folgenden Weg
 
-```bash
+``` plain
 (Clients) -> Fritz!Box -> Pi-hole -> Upstream DNS Server
 ```
 
 Zum Einstellen muss die IP des Pi-hole als "Bevorzugter DNSv4-Server" **und** "Alternativer DNSv4-Server" in
 
-```bash
+``` plain
 Internet/Zugangsdaten/DNS-Server
 ```
 
@@ -65,7 +65,7 @@ Wird ausschließlich diese Konfiguration genutzt, sind im Pi-hole Dashboard kein
 
 Es gibt in der Fritz!Box keine Möglichkeit unter
 
-```bash
+``` plain
 Heimnetz/Netzwerk/Netzwerkeinstellungen/IP-Adressen/IPv4-Konfiguration/Gastnetz
 ```
 
@@ -90,3 +90,80 @@ Folgende Einstellungen müssen dafür vorgenommen werden:
     * **Local domain name (optional):** Name der lokalen Domän, für die Fritz!Box **fritz.box**
 
 ![Screenshot der Conditional Forwarding Einstellungen](../images/routers/conditional-forwarding.png)
+
+## Optional: Erhöhung der Priorität von DNS Anfragen
+
+Bei ausgelasteter Internetverbindung werden DNS-Anfragen u.U. stark verzögert bearbeitet. Dies kann in der Fritz!Box durch Hinterlegen von DNS als priorisierter Echtzeitanwendung vermieden werden. Falls nicht bereits geschehen, fügen Sie hierfür zunächst "`DNS`" als neuen Answendungstyp unter
+
+``` plain
+Internet/Filter/Listen -> Netzwerkanwendungen -> Netzwerkanwendung hinzufügen
+```
+
+mit den Eigenschaften
+
+``` plain
+Netzwerkanwendung: DNS
+Protokoll: UDP
+Quellport: beliebig
+Zielport: 53
+```
+
+sowie
+
+``` plain
+Netzwerkanwendung: TCP
+Protokoll: UDP
+Quellport: beliebig
+Zielport: 53
+```
+
+hinzu.
+
+Dieser Eintrag kann dann unter
+
+``` plain
+Internet/Filter/Priorisierung -> Echtzeitanwendungen -> Neue Regel
+```
+
+hinzugefügt werden. Da sämtliche Einstellungen über das Pi-hole gehen, wählen Sie dieses als Gerät aus, für das die Regel gelten soll. Sollten Sie sich unsicher sein, kann hier auch "`Alle Geräte`" ausgewählt werden. Unter "`Netzwerkanwendung`" wählen Sie den soeben angelegten Eintrag "`DNS`" aus.
+
+## Optional: DNS Anfragen nur vom Pi-hole erlauben
+
+Nach der Konfiguration des Pi-holes als DNS Server des Netzwerks ist die Einrichtung abgeschlossen. Es bleibt jedoch weiterhin das Risiko einer Umgehung des Pi-holes bestehen - Netzwerkgeräte können sich direkt mit anderen, frei verfügbaren, DNS Servers im Internet verbinden. Dies kann durch eine geeignete Fiterregel jedoch einfach verhindert werden.
+
+Insofern nicht bereits vorhanden, legen Sie unter
+
+``` plain
+Internet/Filter/Zugangsprofile -> Zugangsprofile verwalten und optimal nutzen
+```
+
+zwei Zugangsprofile an (z.B. "`Standard`" und "`Unbeschränkt`"). Im Profil "`Standard`" fügen Sie unter
+
+``` plain
+Erweiterte Einstellungen -> Gesperrte Netzwerkanwendungen
+```
+
+die oben angelegte Netzwerkanwendung "`DNS`" hinzu.
+Im Profil "`Unbeschränkt`" darf "`DNS`" *nicht* als gesperrt hinterlegt werden.
+
+Nun werden die Zugangsprofile unter
+
+``` plain
+Internet/Filter/Kindersicherung -> Zugangsprofile ändern (am Ende der Seite)
+```
+
+so konfiguriert, dass *sämtliche* Geräte *außer* dem Pi-hole (inkl. "`Alle anderen Geräte`") dem Zugangsprofil "`Standard`" (DNS wird blockiert) zugewiesen werden. Das Pi-hole selbst wird dem Zugangsprofil ("`Unbeschränkt`") zugeordnet um weiterhin DNS Anfragen absetzen zu können. Die Regel wird unmittelbar nach dem Speichern aktiv.
+
+Die neue Filterregel kann z.B. durch den Aufruf von
+
+``` bash
+dig google.com @8.8.8.8 +short
+```
+
+auf dem Pi-Hole und auf einem beliebigen anderen Gerät im Netzwerk getestet werden. Während die Abfrage auf dem Pi-hole wie erwartet eine IP-Adresse zurückgeben sollte, sollte auf allen anderen Geräten eine Fehlermeldung wie
+
+``` plain
+;; communications error to 8.8.8.8#53: host unreachable
+```
+
+angezeigt werden. Dies belegt, dass DNS-Bypassing nun von der Fritz!Box blockiert wird.

--- a/docs/routers/fritzbox-de.md
+++ b/docs/routers/fritzbox-de.md
@@ -111,8 +111,8 @@ Zielport: 53
 sowie
 
 ``` plain
-Netzwerkanwendung: TCP
-Protokoll: UDP
+Netzwerkanwendung: DNS
+Protokoll: TCP
 Quellport: beliebig
 Zielport: 53
 ```
@@ -132,7 +132,7 @@ hinzugefügt werden. Wählen Sie nun ihr Pi-hole aus. Sollten Sie sich unsicher 
 Nach der Konfiguration des Pi-holes als DNS Server des Netzwerks ist die Einrichtung abgeschlossen. Es bleibt jedoch weiterhin das Risiko einer Umgehung des Pi-holes bestehen - Netzwerkgeräte können sich direkt mit anderen, frei verfügbaren, DNS Servers im Internet verbinden. Dies kann durch eine geeignete Fiterregel jedoch einfach verhindert werden.
 
 !!! warning
-    Einige Geräte oder Programme nutzen fest hinterlegte DNS Server und funktionieren ggfs. nicht mehr ordnungsgemäß falls sie diesen DNS Server nicht erreichen können. Fall solch ein Verhalten auftritt, können Sie dieses Gerät von der Filterregel ausnehmen ausnehmen.
+    Einige Geräte oder Programme nutzen fest hinterlegte DNS Server und funktionieren ggfs. nicht mehr ordnungsgemäß falls sie diesen DNS Server nicht erreichen können. Fall solch ein Verhalten auftritt, können Sie dieses Gerät von der Filterregel ausnehmen.
 Insofern nicht bereits vorhanden, legen Sie unter
 
 ``` plain
@@ -145,7 +145,7 @@ zwei Zugangsprofile an (z.B. "`Standard`" und "`Unbeschränkt`"). Im Profil "`St
 Erweiterte Einstellungen -> Gesperrte Netzwerkanwendungen
 ```
 
-die wie unter `Optional: Erhöhung der Priorität von DNS Anfragen` beschrieben angelegte Netzwerkanwendung "`DNS`" hinzu.
+die [angelegte Netzwerkanwendung "`DNS`"](/routers/fritzbox-de/#optional-erhohung-der-prioritat-von-dns-anfragen) hinzu.
 Im Profil "`Unbeschränkt`" darf "`DNS`" *nicht* als gesperrt hinterlegt werden.
 
 Nun werden die Zugangsprofile unter

--- a/docs/routers/fritzbox.md
+++ b/docs/routers/fritzbox.md
@@ -112,7 +112,6 @@ Source port: any
 Destination port: 53
 ```
 
-should be added.
 
 This entry can then be added under
 
@@ -120,11 +119,14 @@ This entry can then be added under
 Internet/Filter/Prioritization -> Real-time applications -> New rule
 ```
 
-Since all settings go through the Pi-hole, select this as the device to which the rule should apply. If you are unsure, "`All devices`" may also be useful selection here. As "`Network Application`" select the entry you just created "`DNS`".
+Select your Pi-hole as the device to which the rule should apply. If you are unsure, "`All devices`" may also be useful selection here. As "`Network Application`" select the "`DNS`" entry you just created.
 
 ## Optional: Allow DNS queries only from the Pi-hole
 
 After configuring the Pi-hole as the network's DNS server, the setup is complete. However, there is still a risk of clients trying to bypass your Pi-hole as network devices can connect directly to other, freely available, DNS servers on the Internet. However, this can be easily prevented by a suitable filter rule.
+
+!!! warning
+    Some devices or applications use hard-coded DNS servers and may not work as expected if they can't be reached. If you observe such behavior, you can easily remove the affected device from this filter.
 
 If not already present, create two access profiles (e.g. "`Standard`" and "`Unrestricted`") under
 
@@ -132,7 +134,7 @@ If not already present, create two access profiles (e.g. "`Standard`" and "`Unre
 Internet/Filters/Access Profiles -> Manage and Optimize Access Profiles
 ```
 
-In the profile "`Standard`" add the network application "`DNS`" created above under:
+In the profile "`Standard`" add the network application "`DNS`" (created above in `Optional: Increasing the priority of DNS requests`) under:
 
 ``` plain
 Advanced settings -> Locked network applications

--- a/docs/routers/fritzbox.md
+++ b/docs/routers/fritzbox.md
@@ -126,7 +126,7 @@ Select your Pi-hole as the device to which the rule should apply. If you are uns
 After configuring the Pi-hole as the network's DNS server, the setup is complete. However, there is still a risk of clients trying to bypass your Pi-hole as network devices can connect directly to other, freely available, DNS servers on the Internet. However, this can be easily prevented by a suitable filter rule.
 
 !!! warning
-    Some devices or applications use hard-coded DNS servers and may not work as expected if they can't be reached. If you observe such behavior, you can easily remove the affected device from this filter.
+    Some devices or applications use hard-coded DNS servers and may not work as expected if they can't  reach the desired DNS server. If you observe such behavior, you can easily remove the affected device from this filter.
 
 If not already present, create two access profiles (e.g. "`Standard`" and "`Unrestricted`") under
 
@@ -134,7 +134,7 @@ If not already present, create two access profiles (e.g. "`Standard`" and "`Unre
 Internet/Filters/Access Profiles -> Manage and Optimize Access Profiles
 ```
 
-In the profile "`Standard`" add the network application "`DNS`" (created above in `Optional: Increasing the priority of DNS requests`) under:
+In the profile "`Standard`" add the network application "`DNS`" ([created above](/routers/fritzbox/#optional-increasing-the-priority-of-dns-requests)) under:
 
 ``` plain
 Advanced settings -> Locked network applications

--- a/docs/routers/fritzbox.md
+++ b/docs/routers/fritzbox.md
@@ -15,7 +15,7 @@ Some of the following settings might be visible only if advanced settings are en
 Using this configuration, all clients will get Pi-hole's IP offered as DNS server when they request a DHCP lease from your Fritz!Box.
 DNS queries take the following path
 
-```bash
+``` plain
 Client -> Pi-hole -> Upstream DNS Server
 ```
 
@@ -25,7 +25,7 @@ Client -> Pi-hole -> Upstream DNS Server
 
 To set it up, enter Pi-hole's IP as "Local DNS server" in
 
-```bash
+``` plain
 Home Network/Network/Network Settings/IP Addresses/IPv4 Configuration/Home Network
 ```
 
@@ -41,13 +41,13 @@ Now you should see individual clients in Pi-hole's web dashboard.
 
 With this configuration, Pi-hole is also used by the Fritz!Box itself as an upstream DNS server. DNS queries take the following path
 
-```bash
+``` plain
 (Clients) -> Fritz!Box -> Pi-hole -> Upstream DNS Server
 ```
 
 To set it up, enter Pi-hole's IP as "Preferred DNSv4 server" **and** "Alternative DNSv4 server" in
 
-```bash
+``` plain
 Internet/Account Information/DNS server
 ```
 
@@ -62,7 +62,7 @@ If only this configuration is used, you won't see individual clients in Pi-hole'
 
 There is no option to set the DNS server for the guest network in
 
-```bash
+``` plain
 Home Network/Network/Network Settings/IP Addresses/IPv4 Configuration/Guest Network
 ```
 
@@ -85,3 +85,79 @@ The following settings must be made:
     * **Local domain name (optional):** Fritz!Box uses **fritz.box**
 
 ![Screenshot der Conditional Forwarding Einstellungen](../images/routers/conditional-forwarding.png)
+
+## Optional: Increasing the priority of DNS requests
+
+When the Internet connection is busy, DNS queries may only be processed with a long delay. This can be avoided in the Fritz!Box by adding DNS as a prioritized real-time application. If you have not already done so, first add "`DNS`" as a new application type under
+
+``` plain
+Internet/Filter/Lists -> Network Applications -> Add Network Application
+```
+
+with the properties
+
+``` plain
+Network application: DNS
+Protocol: UDP
+Source port: any
+Destination port: 53
+```
+
+and
+
+``` plain
+Network application: DNS
+Protocol: TCP
+Source port: any
+Destination port: 53
+```
+
+should be added.
+
+This entry can then be added under
+
+``` plain
+Internet/Filter/Prioritization -> Real-time applications -> New rule
+```
+
+Since all settings go through the Pi-hole, select this as the device to which the rule should apply. If you are unsure, "`All devices`" may also be useful selection here. As "`Network Application`" select the entry you just created "`DNS`".
+
+## Optional: Allow DNS queries only from the Pi-hole
+
+After configuring the Pi-hole as the network's DNS server, the setup is complete. However, there is still a risk of clients trying to bypass your Pi-hole as network devices can connect directly to other, freely available, DNS servers on the Internet. However, this can be easily prevented by a suitable filter rule.
+
+If not already present, create two access profiles (e.g. "`Standard`" and "`Unrestricted`") under
+
+``` plain
+Internet/Filters/Access Profiles -> Manage and Optimize Access Profiles
+```
+
+In the profile "`Standard`" add the network application "`DNS`" created above under:
+
+``` plain
+Advanced settings -> Locked network applications
+```
+
+In the profile "`Unrestricted`" "`DNS`" must *not* be set as blocked.
+
+Now the access profiles under
+
+``` plain
+Internet/Filters/Parental Control -> Change Access Profiles (at the bottom of the page)
+```
+
+are configured such that *all* devices *except* the Pi-hole (including "`All other devices`") are assigned to the access profile "`Standard`" (DNS is blocked). The Pi-hole itself is assigned to the access profile "Unrestricted" to be able to send DNS queries. The rule becomes active immediately after saving.
+
+You can easily test whether this is working by trying
+
+``` bash
+dig google.com @8.8.8.8 +short
+```
+
+once on your Pi-hole and once on any other device in your network. While the query on your Pi-hole should return an IP address as expected, you should see an error such as
+
+``` plain
+;; communications error to 8.8.8.8#53: host unreachable
+```
+
+on any other device verifying that DNS-bypassing is now blocked by our Fritz!Box.


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Extend FritzBox guide: 
1. make DNS a realtime-service. This assigns priority when the connection is completely used, e.g. by a running download and,
2. add filter (= firewall) instructions to block port 53/UDP for devices in your local network except the Pi-hole


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered, and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
10. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
