### PR TITLE
Update dnsmasq_warn.md

### DIFF
--- a/docs/ftldns/dnsmasq_warn.md
+++ b/docs/ftldns/dnsmasq_warn.md
@@ -133,7 +133,7 @@ Warnings commonly seen in `dnsmasq`'s log file (`/var/log/pihole/pihole.log`) an
     edns-packet-max=1232
     ```
 
-    After running `pihole restartdns` your Pi-hole will not even try larger packet sizes (the default is 4096). Check out our [unbound guide](../guides/dns/unbound.md) for a comment about the particular value of `1232`.
+    After running `pihole restartdns` your Pi-hole will not even try larger packet sizes (the default is 4096). Check out our [unbound guide](../guides/dns/unbound.md) for a comment about the particular value of `1232` or reference [this comment](https://discourse.pi-hole.net/t/dnsmasq-warn-reducing-dns-packet-size/51803/31) regarding the various allowed packet sizes for the various upstream DNS servers.
 
 !!! warning "Ignoring query from non-local network"
 


### PR DESCRIPTION
add a link to more info on allowed packet sizes. allows pi-hole users to configure packet max size according to the individual upstream DNS service's max allowable packet size.

Signed-off-by: benbrookshire <42323694+benbrookshire@users.noreply.github.com>

(I've ignored the more extension rules for PRs bc this is just a text update in docs)
