### PR TITLE
Tweaks for the valgrind guide

### DIFF
--- a/docs/ftldns/valgrind.md
+++ b/docs/ftldns/valgrind.md
@@ -44,13 +44,13 @@ They'll automatically be re-added when using `sudo service pihole-FTL start` nex
 We suggest the following one-liner to run `pihole-FTL` in `memcheck`:
 
 ```
-sudo rm /dev/shm/FTL-*; sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes -s /usr/bin/pihole-FTL &> valgrind.log
+sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s /usr/bin/pihole-FTL
 ```
 
 If you compile FTL from source, use
 
 ```
-sudo rm /dev/shm/FTL-*; ./build.sh && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes -s ./pihole-FTL &> valgrind.log
+./build.sh && sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s ./pihole-FTL
 ```
 
 The used options are:

--- a/docs/ftldns/valgrind.md
+++ b/docs/ftldns/valgrind.md
@@ -44,13 +44,27 @@ They'll automatically be re-added when using `sudo service pihole-FTL start` nex
 We suggest the following one-liner to run `pihole-FTL` in `memcheck`:
 
 ```
-sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s /usr/bin/pihole-FTL
+sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL
+sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s /usr/bin/pihole-FTL
 ```
 
 If you compile FTL from source, use
 
 ```
-./build.sh && sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s ./pihole-FTL
+sudo service pihole-FTL stop && sudo setcap -r /usr/bin/pihole-FTL
+./build.sh && sudo valgrind --trace-children=yes --leak-check=full --track-origins=yes --log-file=valgrind.log -s ./pihole-FTL
+```
+
+The most useful information (about which memory is *possibly* and which is *definitely* lost) is written to `valgrind.log` at the end of the analysis. Terminate FTL by running:
+
+```bash
+sudo kill -TERM $(cat /var/run/pihole-FTL.pid)
+```
+
+and immediately restart it (and fix permissions) using
+
+```bash
+sudo service pihole-FTL start
 ```
 
 The used options are:


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Improve `valgrind` guide. Using the `--log-file` options instead of piping the command itself is able to also catch all the forked child processes.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
