### PR TITLE
Unbound guide: Add AppArmor instructions for logging

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -271,11 +271,27 @@ sudo touch /var/log/unbound/unbound.log
 sudo chown unbound /var/log/unbound/unbound.log
 ```
 
-Third, restart unbound:
+On modern Debian/Ubuntu-based Linux systems, you'll also have to add an AppArmor exception for this new file so `unbound` can write into it.
+
+Create (or edit if existing) the file `/etc/apparmor.d/local/usr.sbin.unbound` and append
+
+``` plain
+/var/log/unbound/unbound.log rw,
+```
+
+to the end (make sure this value is the same as above). Then reload AppArmor using
+
+``` bash
+sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.unbound
+sudo service unbound restart
+```
+
+Lastly, restart unbound:
 
 ```
 sudo service unbound restart
 ```
+
 
 ### Uninstall `unbound`
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix `unbound` guide concerning the optional query/debug logging. The guide was accurate for older versions, however, `unbound` received rather strict `apparmor` rules recently preventing it from creating any file besides the default ones without a proper exception. This prevents `unbound` from creating the manually added log files.

See https://discourse.pi-hole.net/t/unbound-not-working-even-with-extra-steps/60117/10 for details.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
