### PR TITLE
Wireguard: nftables preferable over iptables

### DIFF
--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -54,7 +54,7 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 !!! warning "**Important:** Substitute interface"
     **Without the correct interface name, this will not work!**
 
-    Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `enp2s0` or similar on more recent Ubuntu versions (check, e.g., `ip a` for details about your local interfaces). If you are unsure, you can use `ip a` to find the correct interface name. The interface name is the one that is connected to the Internet.
+    Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `enp2s0` or similar on more recent Ubuntu versions. If you are unsure, you can use `ip a` to find the correct interface name. The interface name is the one that is connected to the Internet.
 
     If you are using the `nftables` method, you do not need to specify the interface name in the `PostUp` and `PostDown` lines.
 <!-- markdownlint-enable code-block-style -->
@@ -70,8 +70,8 @@ The rules will then be cleared once the tunnel is down.
     Address = [Wireguard-internal IPs of the server, e.g. 10.100.0.1/24, fd08:4711::1/64]
     ListenPort = 47111
 
-    PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o enp2s0 -j MASQUERADE
-    PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o enp2s0 -j MASQUERADE
+    PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain counter packets 0 bytes 0 masquerade
+    PostDown = nft delete table ip wireguard; nft delete table ip6 wireguard
 
     # Android phone
     [Peer]

--- a/docs/guides/vpn/wireguard/internal.md
+++ b/docs/guides/vpn/wireguard/internal.md
@@ -30,7 +30,20 @@ A properly configured firewall is ***highly*** recommended for any Internet-faci
 
 ## Enable NAT on the server
 
+### `nftables` (most distributions)
+
 On your server, add the following to the `[INTERFACE]` section of your `/etc/wireguard/wg0.conf`:
+
+```bash
+PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain counter packets 0 bytes 0 masquerade
+PostDown = nft delete table ip wireguard; nft delete table ip6 wireguard
+```
+
+You may need to install `nftables` using `sudo apt-get install nftables`.
+
+### `iptables` (older distributions)
+
+If you are using a different distribution, you may need to use `iptables` instead of `nftables`. In this case, add the following to the `[INTERFACE]` section of your `/etc/wireguard/wg0.conf`:
 
 ```bash
 PostUp = iptables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w -t nat -A POSTROUTING -o eth0 -j MASQUERADE
@@ -41,19 +54,9 @@ PostDown = iptables -w -t nat -D POSTROUTING -o eth0 -j MASQUERADE; ip6tables -w
 !!! warning "**Important:** Substitute interface"
     **Without the correct interface name, this will not work!**
 
-    Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `enp2s0` or similar on more recent Ubuntu versions (check, e.g., `ip a` for details about your local interfaces).
-<!-- markdownlint-enable code-block-style -->
+    Substitute `eth0` in the preceding lines to match the Internet-facing interface. This may be `enp2s0` or similar on more recent Ubuntu versions (check, e.g., `ip a` for details about your local interfaces). If you are unsure, you can use `ip a` to find the correct interface name. The interface name is the one that is connected to the Internet.
 
-<!-- markdownlint-disable code-block-style -->
-!!! warning "**Important:** Debian Bullseye (Debian 11) and Raspian 11"
-    Debian Bullseye doesn't include iptables per default and uses nftables.
-    (you may need to install `nftables` using `sudo apt-get install nftables`)
-
-    We have to set following rules for PostUP and PostDown:
-    ```bash
-    PostUp = nft add table ip wireguard; nft add chain ip wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade; nft add table ip6 wireguard; nft add chain ip6 wireguard wireguard_chain {type nat hook postrouting priority srcnat\; policy accept\;}; nft add rule ip6 wireguard wireguard_chain oifname "eth0" counter packets 0 bytes 0 masquerade
-    PostDown = nft delete table ip wireguard; nft delete table ip6 wireguard
-    ```
+    If you are using the `nftables` method, you do not need to specify the interface name in the `PostUp` and `PostDown` lines.
 <!-- markdownlint-enable code-block-style -->
 
 `PostUp` and `PostDown` defines steps to be run after the interface is turned on or off, respectively. In this case, iptables is used to set Linux IP masquerade rules to allow all the clients to share the server’s IPv4 and IPv6 address.

--- a/docs/guides/vpn/wireguard/server.md
+++ b/docs/guides/vpn/wireguard/server.md
@@ -15,7 +15,7 @@ Installing everything we will need for a `wireguard` connections is as simple as
 sudo apt-get install wireguard wireguard-tools
 ```
 
-For Ubuntu 18.04 and lower, you need to do some extra steps:
+For Ubuntu 18.04 and before, you need to do some extra steps:
 
 ```bash
 sudo add-apt-repository ppa:wireguard/wireguard


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

`ntftables` is by now the preferred method. It also has the benefit that we do not need to hard-code an interface. In this case, `nftables` can identify the correct interface to forward the packets to (typically the Internet) solely by looking at the kernel's routing table

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
