### PR TITLE
;querytype=... list support

### DIFF
--- a/docs/database/ftl.md
+++ b/docs/database/ftl.md
@@ -103,9 +103,11 @@ ID | Resource Record (a.k.a. query type)
 11 | `RRSIG`
 12 | `DNSKEY`
 13 | `NS`
-14 | `OTHER` (any query type not covered elsewhere)
+14 | `OTHER` (any query type not covered elsewhere, but see note below)
 15 | `SVCB`
 16 | `HTTPS`
+
+Any other query type will be stored with an offset of 100, i.e., `TYPE66` will be stored as `166` in the database (see [pi-hole/FTL #1013](https://github.com/pi-hole/FTL/pull/1013)). This is done to allow for future extensions of the query type list without having to change the database schema. The `OTHER` query type is deprecated since Pi-hole FTL v5.4 (released Jan 2021) and not used anymore. It is kept for backwards compatibility. Note that `OTHER` is still used for the [regex extension `querytype=`](../regex/pi-hole.md#querytype) filter and used for all queries not covered by the above list.
 
 ### Supported status types
 

--- a/docs/regex/pi-hole.md
+++ b/docs/regex/pi-hole.md
@@ -2,7 +2,7 @@
 
 ## Only match specific query types
 
-You can amend the regular expressions by special keywords added at the end to fine-tine regular expressions to match only specific [query types](../database/ftl.md#supported-query-types).
+You can amend the regular expressions by special keywords added at the end to fine-tine regular expressions to match only specific [query types](../database/ftl.md#supported-query-types). In contrast to the description of `OTHER` as being deprecated for storing queries in the database, it is still supported for regular expressions and will match all queries that are not *explicitly* covered by the other query types (see also example below).
 
 Example:
 
@@ -37,6 +37,12 @@ Some user-provided examples are:
 - `.*;querytype=ANY`
 
     A regex blacklist entry to block `ANY` request network wide.
+
+- `.*;querytype=OTHER`
+
+    A regex blacklist entry to block `OTHER` request network wide. This rule will match, for instance, proprietary DNS requests using custom query types in the reserved range or queries for seldom used DNS record types like `IXFR` or `AXFR`.
+
+Note that multiple (comma-separated) query types can be specified at the same time, e.g., `.*;querytype=A,AAAA` will match both `A` and `AAAA` requests. In a similar fashion, an inverted (`!` modifier) list, e.g., `.*;querytype=!A,AAAA` will match everything *except* `A` and `AAAA` requests.
 
 ## Invert matching
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Document support of comma-separated query types in the regex extension `;querytype=A,AAAA.` Furthermore, be a bit more explicit about what OTHER means in which context.

Fixes #851 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
