### PR TITLE
Tweak unbound instruction

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -183,9 +183,9 @@ Finally, configure Pi-hole to use your recursive DNS server by specifying `127.0
 
 (don't forget to hit Return or click on `Save`)
 
-### Disable `resolvconf.conf` entry for `unbound` (Required for Debian Bullsye+ releases)
+### Disable `resolvconf.conf` entry for `unbound` (Required for Debian Bullseye+ releases)
 
-Debian Bullsye+ releases auto-install a package called [`openresolv`](https://wiki.archlinux.org/title/Openresolv) with a certain configuration that will cause unexpected behaviour for pihole and unbound. The effect is that the `unbound-resolvconf.service` instructs `resolvconf` to write `unbound`'s own DNS service at `nameserver 127.0.0.1` , but without the 5335 port, into the file `/etc/resolv.conf`. That `/etc/resolv.conf` file is used by local services/processes to determine DNS servers configured. You need to edit the configuration file and disable the service to work-around the misconfiguration.
+Debian Bullseye+ releases auto-install a package called [`openresolv`](https://wiki.archlinux.org/title/Openresolv) with a certain configuration that will cause unexpected behaviour for pihole and unbound. The effect is that the `unbound-resolvconf.service` instructs `resolvconf` to write `unbound`'s own DNS service at `nameserver 127.0.0.1` , but without the 5335 port, into the file `/etc/resolv.conf`. That `/etc/resolv.conf` file is used by local services/processes to determine DNS servers configured. You need to edit the configuration file and disable the service to work-around the misconfiguration.
 
 #### Step 1 - Disable the Service
 
@@ -195,7 +195,7 @@ To check if this service is enabled for your distribution, run below one. It wil
 systemctl is-active unbound-resolvconf.service
 ```
 
-To disable the service, run the two statements below:
+To disable the service, run the statement below:
 
 ```bash
 sudo systemctl disable --now unbound-resolvconf.service


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Tweaks the instruction on how to disable `resolvconf.conf` entry for unbound based on https://discourse.pi-hole.net/t/warning-raspbian-october-2021-release-bullseye-unbound/51027/53?u=yubiuser

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
