### PR TITLE
Small typo in setup for unbound with pi-hole and AppArmor

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -264,7 +264,7 @@ to the end (make sure this value is the same as above). Then reload AppArmor usi
 
 ``` bash
 sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.unbound
-sudo service unbound restart
+sudo service apparmor restart
 ```
 
 Lastly, restart unbound:


### PR DESCRIPTION
Just a quick fix for a typo in the instructions for setting up AppArmor with unbound and pi-hole. 