### PR TITLE
unbound guide: Remove edns-packet-max recommendation

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -156,14 +156,6 @@ dig pi-hole.net @127.0.0.1 -p 5335
 
 The first query may be quite slow, but subsequent queries, also to other domains under the same TLD, should be fairly quick.
 
-You should also consider adding
-
-``` plain
-edns-packet-max=1232
-```
-
-to a config file like `/etc/dnsmasq.d/99-edns.conf` to signal FTL to adhere to this limit.
-
 ### Test validation
 
 You can test DNSSEC validation using
@@ -222,16 +214,14 @@ sudo service unbound restart
 !!! warning
     It's not recommended to increase verbosity for daily use, as unbound logs a lot. But it might be helpful for debugging purposes.
 
-There are five levels of verbosity
+There are five levels of verbosity:
 
-```
-Level 0 means no verbosity, only errors
-Level 1 gives operational information
-Level 2 gives  detailed operational  information
-Level 3 gives query level information
-Level 4 gives  algorithm  level  information
-Level 5 logs client identification for cache misses
-```
+- Level 0 means no verbosity, only errors
+- Level 1 gives operational information
+- Level 2 gives detailed operational  information
+- Level 3 gives query level information
+- Level 4 gives algorithm level information
+- Level 5 logs client identification for cache misses
 
 First, specify the log file, human-readable timestamps and the verbosity level in the `server` part of
 `/etc/unbound/unbound.conf.d/pi-hole.conf`:


### PR DESCRIPTION
# What does this implement/fix?

Remove recommendation to manually configured `edns-packet-max=1232`. This is the default in dnsmasq for almost two years now, both in `development` as well as in `master` as of [FTL v5.22](https://github.com/pi-hole/FTL/releases/tag/v5.22) (March 2023).

Related commit from 2023: https://github.com/pi-hole/FTL/commit/e5c5a34dd772d1b421fc95e4195c0e2c88f5294d

**edit** Related Discourse thread: https://discourse.pi-hole.net/t/etc-pihole-pihole-toml-makes-me-very-happy/75660/3

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.