### PR TITLE
Prevent reverse dns requests from non-routable zones. (RFC6303 4.2)

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -145,6 +145,13 @@ server:
     private-address: 10.0.0.0/8
     private-address: fd00::/8
     private-address: fe80::/10
+
+    # Ensure no reverse queries to non-public IP ranges (RFC6303 4.2)
+    private-address: 192.0.2.0/24
+    private-address: 198.51.100.0/24
+    private-address: 203.0.113.0/24
+    private-address: 255.255.255.255/32
+    private-address: 2001:db8::/32
 ```
 
 Start your local recursive server and test that it's operational:


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adding the remaining zones from RFC6303 section 4.2 - 4.6 prevents reverse dns lookups from being sent in the event of a misconfigured or malicious device on the network. This is best practice for recursive dns resolvers.

**How does this PR accomplish the above?:**

Adds the remaining zones from RFC6303 section 4.2 - 4.6 
(The other zones are already either specified within unbound, or within the file)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ X] I have read the above and my PR is ready for review. *Check this box to confirm*

Edited to update RFC sections referenced.
