### PR TITLE
Use external file to show always up-to-date `pihole.toml` content

### DIFF
--- a/docs/ftldns/configfile.md
+++ b/docs/ftldns/configfile.md
@@ -5,3 +5,9 @@ The configuration file can be found at `/etc/pihole/pihole.toml`, all of the opt
 The file can be edited directly, however you can also use the command line option (`pihole-FTL --config`) or the web interface.
 
 There is also an outline of the configuration options in the [api documentation](../api/index.md#accessing-the-api-documentation).
+
+## Pi-hole configuration file example - `pihole.toml`:
+
+```toml
+--8<-- "https://raw.githubusercontent.com/pi-hole/FTL/refs/heads/master/test/pihole.toml"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,8 @@ markdown_extensions:
   - markdown_include.include:
       base_path: docs
   - pymdownx.snippets:
+      # allow include external URL content
+      url_download: true
       # auto_append abbreviations.md to every file
       # https://squidfunk.github.io/mkdocs-material/reference/tooltips/#adding-a-glossary
       auto_append:


### PR DESCRIPTION
### What does this PR aim to accomplish?

As title says.

### How does this PR accomplish the above?

Using snippets (already used) to import an external URL with the most recent `pihole.toml`.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
