### PR TITLE
Be explicit about setting a blank password in docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
     "GIT_EDITOR": "nano"
   },
   "mounts": [
-    "type=bind,source=/home/${localEnv:USER}/.ssh,target=/home/node/.ssh,readonly"
+    "type=bind,source=${localEnv:HOME}/.ssh,target=/home/node/.ssh,readonly"
   ],
   "forwardPorts": [8000]
 }

--- a/docs/docker/configuration.md
+++ b/docs/docker/configuration.md
@@ -45,8 +45,7 @@ Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 To set a specific password for the web interface, use the environment variable `FTLCONF_webserver_api_password` (per the quick-start example). If this variable is not detected, and you have not already set one previously inside the container via `pihole setpassword` or `pihole-FTL --config webserver.api.password`, then a random password will be assigned on startup, and will be printed to the log. You can find this password with the command `docker logs pihole | grep random password` on your host to find this password. See [Notes On Web Interface Password](#notes-on-web-interface-password) below for usage examples.
 
 !!! note
-    To _explicitly_ set no password, set `FTLCONF_webserver_api_password: ''`
-
+    To _explicitly_ set no password, set `FTLCONF_webserver_api_password: ''`<br/><br/>
     Using `pihole setpassword` for the purpose of setting an empty password will not persist between container restarts
 
 #### `FTLCONF_dns_upstreams` (Default: `8.8.8.8;8.8.4.4`)

--- a/docs/docker/configuration.md
+++ b/docs/docker/configuration.md
@@ -44,6 +44,11 @@ Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 To set a specific password for the web interface, use the environment variable `FTLCONF_webserver_api_password` (per the quick-start example). If this variable is not detected, and you have not already set one previously inside the container via `pihole setpassword` or `pihole-FTL --config webserver.api.password`, then a random password will be assigned on startup, and will be printed to the log. You can find this password with the command `docker logs pihole | grep random password` on your host to find this password. See [Notes On Web Interface Password](#notes-on-web-interface-password) below for usage examples.
 
+!!! note
+    To _explicitly_ set no password, set `FTLCONF_webserver_api_password: ''`
+
+    Using `pihole setpassword` for the purpose of setting an empty password will not persist between container restarts
+
 #### `FTLCONF_dns_upstreams` (Default: `8.8.8.8;8.8.4.4`)
 
 - Upstream DNS server(s) for Pi-hole to forward queries to, separated by a semicolon


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Companion/folllowup to https://github.com/pi-hole/docker-pi-hole/pull/1778

includes an extra commit that makes the devcontainer usable on Mac - minor tweak, no sense in doing a whole PR for it - it has the same logic as https://github.com/pi-hole/FTL/pull/2152

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_