### PR TITLE
Remove references to old API port 4711

### DIFF
--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -77,7 +77,6 @@ Pi-hole needs a static IP address to properly function (a DHCP reservation is ju
 | pihole-FTL          | 67  (DHCP)   | IPv4 UDP | The DHCP server is an optional feature that requires additional ports. |
 | pihole-FTL          | 547 (DHCPv6) | IPv6 UDP | The DHCP server is an optional feature that requires additional ports. |
 | pihole-FTL          | 80  (HTTP)<br/>443   (HTTPS)    | TCP      | If you have another webserver already listening on port `80`/`443`, then `pihole-FTL` will attempt to bind to `8080`/`8443` instead. If neither of these ports are available, `pihole-FTL`'s webserver will be unavailable until ports are configured manually (see configuration option `webserver.port`)  |
-| pihole-FTL          | 4711    | TCP      | FTL is our API engine and uses port 4711 on the localhost interface. This port should not be accessible from any other interface.|
 | pihole-FTL          | 123 (NTP)    | UDP      | The NTP server is an optional feature that requires an additional port. |
 
 !!! info
@@ -105,7 +104,6 @@ iptables -I INPUT 1 -s 127.0.0.0/8 -p udp -m udp --dport 53 -j ACCEPT
 iptables -I INPUT 1 -s 192.168.0.0/16 -p tcp -m tcp --dport 53 -j ACCEPT
 iptables -I INPUT 1 -s 192.168.0.0/16 -p udp -m udp --dport 53 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 67:68 --sport 67:68 -j ACCEPT
-iptables -I INPUT 1 -p tcp -m tcp --dport 4711 -i lo -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 123 -j ACCEPT
 iptables -I INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 ```
@@ -125,7 +123,6 @@ Using the `--permanent` argument will ensure the firewall rules persist reboots.
 firewall-cmd --permanent --add-service=http --add-service=https --add-service=dns --add-service=dhcp --add-service=dhcpv6 --add-service=ntp
 firewall-cmd --permanent --new-zone=ftl
 firewall-cmd --permanent --zone=ftl --add-interface=lo
-firewall-cmd --permanent --zone=ftl --add-port=4711/tcp
 firewall-cmd --reload
 ```
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Deletes the references to the old API port 4711 from the docs

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
