### PR TITLE
Update client.md, correct IPv6 range discrepancy with server.md

### DIFF
--- a/docs/guides/vpn/wireguard/client.md
+++ b/docs/guides/vpn/wireguard/client.md
@@ -117,7 +117,7 @@ After a restart, the server file should look like:
 
 ```plain
 [Interface]
-Address = 10.100.0.1/24, fd08:4711::1/128
+Address = 10.100.0.1/24, fd08:4711::1/64
 ListenPort = 47111
 PrivateKey = XYZ123456ABC=                   # PrivateKey will be different
 


### PR DESCRIPTION
Serveur config: correct IPv6 range discrepancy between client.md and server.md


**What does this PR aim to accomplish?:**

In the documentation, there is a discrepancy in the IPv6 address in the server config show in server.md and client.md.

- server.md server config:

> [Interface]
> Address = 10.100.0.1/24, fd08:4711::1/**64**


- Original client.md server config:

> [Interface]
> Address = 10.100.0.1/24, fd08:4711::1/**128**


The mistake seems to be on client.md: "/128" should be "/64."

**How does this PR accomplish the above?:**

It corrects the wrong IPv6 range in the documentation.

**Link documentation PRs if any are needed to support this PR:**
N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
