### PR TITLE
Add info how to add local user to pihole group

### DIFF
--- a/docs/main/post-install.md
+++ b/docs/main/post-install.md
@@ -21,7 +21,7 @@ static domain_name_servers=127.0.0.1
 
 ## Adding your local user to the 'pihole' group
 
-Since version 6 Pi-hole uses a new API for authentication. All CLI commands use this API instead of e.g. direct database manipulation. If a password is set for API access, the CLI commands also need to authenticate. To avoid entering the password everytime on CLI, Pi-hole allows users which are members of the 'pihole' group to authenicate without manually entering the password (this can be disabled with setting `webserver.api.cli_pw` to `false`.)
+Pi-hole v6 uses a new API for authentication. All CLI commands use this API instead of e.g. direct database manipulation. If a password is set for API access, the CLI commands also need to authenticate. To avoid entering the password everytime on CLI, Pi-hole allows users which are members of the 'pihole' group to authenicate without manually entering the password (this can be disabled by setting `webserver.api.cli_pw` to `false`.)
 To add your local user to the 'pihole' group use the following command
 
 For Debian/Ubuntu/Raspberry Pi OS/Armbian/Fedora/CentOS

--- a/docs/main/post-install.md
+++ b/docs/main/post-install.md
@@ -18,3 +18,20 @@ Pi-hole will not be used by the host automatically after installation. To have t
 ```code
 static domain_name_servers=127.0.0.1
 ```
+
+## Adding your local user to the 'pihole' group
+
+Since version 6 Pi-hole uses a new API for authentication. All CLI commands use this API instead of e.g. direct database manipulation. If a password is set for API access, the CLI commands also need to authenticate. To avoid entering the password everytime on CLI, Pi-hole allows users which are members of the 'pihole' group to authenicate without manually entering the password (this can be disabled with setting `webserver.api.cli_pw` to `false`.)
+To add your local user to the 'pihole' group use the following command
+
+For Debian/Ubuntu/Raspberry Pi OS/Armbian/Fedora/CentOS
+
+```code
+sudo usermod -aG pihole $USER
+```
+
+For Alpine
+
+```code
+sudo addgroup pihole $USER
+```


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Amends the post-installation documentation on how to add the local user to the 'pihole' group. This is necessary to access `/etc/pihole` and allow to read the version file as well as `cli_pw` for non-password CLI authenticatin.

Accompanies: https://github.com/pi-hole/pi-hole/pull/6152

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
