### PR TITLE
Removed unavaliable command-line flag documentation

### DIFF
--- a/docs/main/pihole-command.md
+++ b/docs/main/pihole-command.md
@@ -170,7 +170,7 @@ Check Pi-hole Core, Web Interface and FTL repositories to determine what upgrade
 | --------------- | --------------- |
 | Help Command    | `pihole version` |
 | Script Location | [`/opt/pihole/version.sh`](https://github.com/pi-hole/pi-hole/blob/master/advanced/Scripts/version.sh) |
-| Example Usage   | `pihole -v -c` |
+| Example Usage   | `pihole -v` |
 
 Shows installed versions of Pi-hole, Web Interface & FTL. It also provides options to configure which details will be printed, such as the current version, latest version, hash and subsystem.
 

--- a/docs/main/pihole-command.md
+++ b/docs/main/pihole-command.md
@@ -172,7 +172,7 @@ Check Pi-hole Core, Web Interface and FTL repositories to determine what upgrade
 | Script Location | [`/opt/pihole/version.sh`](https://github.com/pi-hole/pi-hole/blob/master/advanced/Scripts/version.sh) |
 | Example Usage   | `pihole -v` |
 
-Shows installed versions of Pi-hole, Web Interface & FTL. It also provides options to configure which details will be printed, such as the current version, latest version, hash and subsystem.
+Shows installed versions of Pi-hole, Web Interface & FTL.
 
 ### Uninstall
 


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!
**What does this PR aim to accomplish?:**

Removing an example usage command-line flag that does nothing from the documentation.
![image](https://github.com/user-attachments/assets/f51604d7-ea37-47e4-a261-ab316d1340d4)


**How does this PR accomplish the above?:**

Changes the documentation

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
