### PR TITLE
Allow Markdown line breaks using 2 trailing spaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ tab_width = 2
 
 [*.md]
 tab_width = 2
+trim_trailing_whitespace = false
 
 [*.json]
 indent_size = 2


### PR DESCRIPTION
### What does this PR aim to accomplish?

This PR fixes `.editorconfig` to allow Markdown line breaks using 2 trailing spaces. 

Currently the Markdownlint settings use MD009 rule with its default options. We also use `.editorconfig` to remove trailing spaces.

The 2 rules are in conflict:

- Markdonwlint MD009 makes sure there are no trailing spaces in a markdown file, but it has an exception to accept **exactly 2 trailing spaces**. This is valid markdown and it is used to force a line break.

- settings in `.editorconfig` considers these line breaks as invalid trailing spaces.


### How does this PR accomplish the above?

Fixing the `.editorconfig` to ignore trailing spaces in markdown files, since this is already checked by Markdownlint.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
