### PR TITLE
Add unbound `rcvbuf` warning troubleshooting documentation

### DIFF
--- a/docs/guides/dns/unbound.md
+++ b/docs/guides/dns/unbound.md
@@ -269,6 +269,54 @@ Lastly, restart unbound:
 sudo service unbound restart
 ```
 
+### Common Issues & Troubleshooting
+
+#### Fix `so-rcvbuf` warning in unbound
+
+The configuration in `/etc/unbound/unbound.conf.d/pi-hole.conf` sets the **socket receive buffer size** for incoming DNS queries to a higher-than-default value in order to handle high query rates:
+
+```bash
+so-rcvbuf: 1m
+```
+
+As a result, you may see this warning in unbound logs:
+
+```bash
+so-rcvbuf 1048576 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.rmem_max(linux) or kern.ipc.maxsockbuf(bsd) values.
+```
+
+To fix it:
+
+1. Check the current limit. This will show something like `net.core.rmem_max = 425984`:
+
+    ```bash
+    sudo sysctl net.core.rmem_max
+    ```
+
+2. Temporarily increase the limit to match unbound's request:
+
+    ```bash
+    sudo sysctl -w net.core.rmem_max=1048576
+    ```
+
+3. Make it permanent. Edit `/etc/sysctl.conf` and add or edit the line:
+
+    ```bash
+    net.core.rmem_max=1048576
+    ```
+
+4. Save and apply:
+
+    ```bash
+    sudo sysctl -p
+    ```
+
+5. Restart unbound:
+
+    ```bash
+    sudo service unbound restart
+    ```
+
 ### Uninstall `unbound`
 
 To remove `unbound` from your system run


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Document solution for `so-rcvbuf 1048576 was not granted` warning that commonly appears in unbound logs.

**How does this PR accomplish the above?:**

Adds a step-by-step troubleshooting section to the unbound guide that explains how to resolve the warning message

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
