### PR TITLE
Update FTL compiling docs

### DIFF
--- a/docs/ftldns/compile.md
+++ b/docs/ftldns/compile.md
@@ -27,9 +27,9 @@ sudo dnf install git wget ca-certificates gcc gmp-devel gmp-static m4 cmake libi
 Compile and install a recent version using:
 
 ```bash
-wget https://ftp.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz
-tar -xzf nettle-3.9.1.tar.gz
-cd nettle-3.9.1
+wget https://ftp.gnu.org/gnu/nettle/nettle-3.10.2.tar.gz
+tar -xzf nettle-3.10.2.tar.gz
+cd nettle-3.10.2
 ./configure --libdir=/usr/local/lib --enable-static --disable-shared --disable-openssl --disable-mini-gmp -disable-gcov --disable-documentation
 make -j $(nproc)
 sudo make install
@@ -44,9 +44,9 @@ Since Ubuntu 20.04, you need to specify the library directory explicitly. Otherw
 Compile and install a recent version using:
 
 ```bash
-wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.5.0.tar.gz -O mbedtls-3.5.0.tar.gz
-tar -xzf mbedtls-3.5.0.tar.gz
-cd mbedtls-3.5.0
+wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.6.4.tar.gz -O mbedtls-3.6.4.tar.gz
+tar -xzf mbedtls-3.6.4.tar.gz
+cd mbedtls-3.6.4
 sed -i '/#define MBEDTLS_THREADING_C/s*^//**g' include/mbedtls/mbedtls_config.h
 sed -i '/#define MBEDTLS_THREADING_PTHREAD/s*^//**g' include/mbedtls/mbedtls_config.h
 make -j $(nproc)
@@ -66,7 +66,7 @@ git clone https://github.com/pi-hole/FTL.git && cd FTL
 If you want to build another branch and not `master`, use checkout to get to this branch, like
 
 ```bash
-git checkout development-v6
+git checkout development
 ```
 
 ## Compile the source


### PR DESCRIPTION
# What does this implement/fix?

Update compiling documentation for FTL following the recent update in https://github.com/pi-hole/docker-base-images/pull/120. Also remove `development-v6` in favor of `development` - the former is no more.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.