### PR TITLE
Fix regex-test return code

### DIFF
--- a/docs/regex/testmode.md
+++ b/docs/regex/testmode.md
@@ -14,4 +14,4 @@ pihole-FTL regex-test doubleclick.net "(^|\.)double"
 
 (test `doubleclick.net` against the CLI-provided regex `(^|\.)double`.
 
-You do NOT need to be `sudo` for this, any arbitrary user should be able to run this command. The test returns `0` on match and `1` on no match and errors, hence, it may be used for scripting.
+You do NOT need to be `sudo` for this, any arbitrary user should be able to run this command. The test returns `0` on match, `1` on errors and `2` on no match, hence, it may be used for scripting.


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/docs/issues/1295

```cpp
// Return status 0 = MATCH, 1 = ERROR, 2 = NO MATCH
return matchidx > -1 ? EXIT_SUCCESS : 2;
```
https://github.com/pi-hole/FTL/blob/e36bf6dd7a154f04bd74cbf3a176f4c0fffa0eb3/src/regex.c#L921-L922


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
