### PR TITLE
Set DNS listening mode to 'ALL' in docker-compose.yml example

### DIFF
--- a/docs/docker/index.md
+++ b/docs/docker/index.md
@@ -26,8 +26,8 @@ services:
       TZ: 'Europe/London'
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
       FTLCONF_webserver_api_password: 'correct horse battery staple'
-      # If using Docker's default `bridge` network setting the dns listening mode should be set to 'all'
-      FTLCONF_dns_listeningMode: 'all'
+      # If using Docker's default `bridge` network setting the dns listening mode should be set to 'ALL'
+      FTLCONF_dns_listeningMode: 'ALL'
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file


### PR DESCRIPTION

**What does this PR aim to accomplish?:**

It changes the docker-compose example listening mode to 'ALL', because 'all' doesn't work (anymore?).

**How does this PR accomplish the above?:**

The current docker-compose file example contains this environment variable:

FTLCONF_dns_listeningMode: 'all'

This was changed to

FTLCONF_dns_listeningMode: 'ALL'

to reflect the [current documentation](https://docs.pi-hole.net/ftldns/configfile/#listeningmode).

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
