### PR TITLE
Fix 2FA examples - TOTP is a number not a string

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -221,7 +221,7 @@ If you have 2FA enabled for your Pi-hole, you will need to provide a TOTP token 
     === "bash / cURL"
 
         ```bash
-        curl -k -X POST "https://pi.hole/api/auth" --data '{"password":"your-password", "totp":"123456"}'
+        curl -k -X POST "https://pi.hole/api/auth" --data '{"password":"your-password", "totp":123456}'
         ```
 
     === "Python 3"
@@ -243,7 +243,7 @@ If you have 2FA enabled for your Pi-hole, you will need to provide a TOTP token 
     === "JavaScript (plain)"
 
         ```javascript
-        var data = JSON.stringify({"password":"your-password", "totp":"123456"});
+        var data = JSON.stringify({"password":"your-password", "totp":123456});
         var xhr = new XMLHttpRequest();
 
         xhr.addEventListener("readystatechange", function () {
@@ -259,7 +259,7 @@ If you have 2FA enabled for your Pi-hole, you will need to provide a TOTP token 
         $.ajax({
           url: "https://pi.hole/api/auth",
           type: "POST",
-          data: JSON.stringify({"password":"your-password", "totp":"123456"}),
+          data: JSON.stringify({"password":"your-password", "totp":123456}),
           dataType: "json",
           contentType: "application/json"
         }).done(function(data) {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes quotes around the TOTP, because it's a number, not a string.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
