### PR TITLE
Add architecture binary information to the prerequisites

### DIFF
--- a/docs/main/prerequisites.md
+++ b/docs/main/prerequisites.md
@@ -46,7 +46,7 @@ Pi-hole only supports actively maintained versions of these systems.
 
 ### Binary architecture
 
-Core part of Pi-hole is the FTL binary which does all the DNS handling. It's provided pre-build for the following architectures
+The binary `pihole-FTL`, which is the resolver at the heart of Pi-hole, is pre-built for the following architectures:
 
 - x86_64 (amd64 and i686)
 - armv6
@@ -54,7 +54,7 @@ Core part of Pi-hole is the FTL binary which does all the DNS handling. It's pro
 - armv8 (aarch64)
 - riscv64
 
-If you need another architecture, you need to compile [FTL from source](../ftldns/compile.md) yourself.
+For other architectures, you will need to compile [FTL from source](../ftldns/compile.md) yourself.
 
 ## IP Addressing
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adds information about the architectures we provide a FTL binary.

This is a reduced version to https://github.com/pi-hole/docs/pull/1237

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
