### PR TITLE
Add instructions how to sign a commit to contribution guidelines

### DIFF
--- a/docs/guides/github/index.md
+++ b/docs/guides/github/index.md
@@ -25,6 +25,7 @@ When requesting or submitting new features, first consider whether it might be u
 - Check the codebase to ensure that your feature doesn't already exist.
 - Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
 - Read and understand the [DCO guidelines](./dco.md)  for the project.
+- Before a pull requets can be accepted, the repo-specific tests need to pass. Please test them locally first.
 
 ### Technical Requirements
 

--- a/docs/guides/github/index.md
+++ b/docs/guides/github/index.md
@@ -25,6 +25,7 @@ When requesting or submitting new features, first consider whether it might be u
 - Check the codebase to ensure that your feature doesn't already exist.
 - Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
 - Read and understand the [DCO guidelines](./dco.md)  for the project.
+- Our repos require users to (cryptographically) sign their commits (which is different to sign-off!). Our recommendation is to use `ssh` keys. Basics steps are [outlined here](./sign.md).
 - Before a pull requets can be accepted, the repo-specific tests need to pass. Please test them locally first.
 
 ### Technical Requirements

--- a/docs/guides/github/sign.md
+++ b/docs/guides/github/sign.md
@@ -1,0 +1,59 @@
+# Signing Git Commits with SSH Keys
+
+## Why Sign Commits?
+
+Signing commits provides:
+
+- **Authentication**: Proves the commit actually came from you
+- **Integrity**: Ensures the commit content hasn't been tampered with
+- **Trust**: GitHub displays a "Verified" badge for signed commits
+- **Security**: Protects against commit spoofing attacks
+
+## Prerequisites
+
+- An SSH key pair (if you don't have one, generate with `ssh-keygen -t ed25519 -C "your_email@example.com"`)
+- SSH key added to your GitHub account
+
+## Setup Instructions
+
+### 1. Configure Git to Use SSH Signing
+
+```bash
+# Set SSH as the signing format
+git config --global gpg.format ssh
+
+# Specify your SSH public key for signing
+git config --global user.signingkey /PATH/TO/.SSH/KEY.PUB
+
+# Optional: Enable automatic signing for all commits
+git config --global commit.gpgsign true
+```
+
+### 2. Add SSH Key to GitHub
+
+1. Copy your SSH public key: `/PATH/TO/.SSH/KEY.PUB`
+2. Go to GitHub → Settings → SSH and GPG keys
+3. Click "New SSH key"
+4. Set Key type to "Signing Key"
+5. Paste your public key and save
+
+### 3. Sign Commits
+
+```bash
+# Sign a single commit
+git commit -S -m "Your commit message"
+
+# If auto-signing is enabled, just commit normally
+git commit -m "Your commit message"
+```
+
+## Verification
+
+- On GitHub: Look for the "Verified" badge next to your commits
+- Locally: `git log --show-signature` displays signature information
+
+
+## Notes
+
+- SSH signing requires Git 2.34+ and GitHub support
+- Your SSH key must be added as a "Signing Key" type in GitHub, not just an authentication key

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
     - 'Developer Certificate of Origin (DCO)': guides/github/dco.md
     - 'How to sign-off commits': guides/github/how-to-signoff.md
     - 'How to fork and rebase': guides/github/how-to-fork-rebase.md
+    - 'How to sign commits': guides/github/sign.md
   - 'Guides':
     - 'DNS':
       - 'unbound': guides/dns/unbound.md


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adds basic instructions to the contribution guidelines on how to sign a commit. I always felt this could be an barrier to new contributors. I personally prefer `ssh` keys but this can be changed if you think we should go for `gpg`


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
