### PR TITLE
Redirect `guides/vpn/overview.md` to wireguard documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,7 +255,7 @@ plugins:
         'guides/unbound.md': guides/dns/unbound.md
         'guides/upstream-dns-providers.md': guides/dns/upstream-dns-providers.md
         'guides/dns-over-https.md': guides/dns/cloudflared.md
-        'guides/vpn/overview.md': guides/vpn/openvpn/index.md
+        'guides/vpn/overview.md': guides/vpn/wireguard/index.md
         'guides/vpn/installation.md': guides/vpn/openvpn/installation.md
         'guides/vpn/setup-openvpn-server.md': guides/vpn/openvpn/setup-openvpn-server.md
         'guides/vpn/firewall.md': guides/vpn/openvpn/firewall.md


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/docs/issues/1393 by redirecting `guides/vpn/overview.md` to the wireguard documentation instead of the deprecated OpenVPN docs,

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
