### PR TITLE
Introduce agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Project overview
+
+The Pi-hole documentation, published at [docs.pi-hole.net](https://docs.pi-hole.net). Built with MkDocs and the Material for MkDocs theme.
+
+## Repository layout
+
+- `docs/` - all documentation content (Markdown), organised by topic (`main/`, `ftldns/`, `api/`, `docker/`, `guides/`, etc.)
+- `mkdocs.yml` - site configuration and navigation. New pages must be added to the `nav` section here.
+- `overrides/` - theme overrides
+- `requirements.txt` - Python dependencies (MkDocs and plugins)
+- `package.json` - npm scripts for building and linting
+
+## Dev environment tips
+
+- Set up with `pip install -r requirements.txt` and `npm install`.
+- Live preview while editing: `npm run serve`
+- Match the surrounding style: sentence-case headings, fenced code blocks with language tags, and the admonition syntax already in use.
+
+## Testing instructions
+
+- Run `npm test` before proposing changes; CI enforces it.
+- This builds the site with `mkdocs build --clean --strict` (broken internal links and nav errors fail the build), then runs markdownlint and a link checker.
+
+## PR instructions
+
+- **This repository uses `master` as its default branch**; pull requests target `master` (unlike most Pi-hole repositories, which use `development`).
+- Read the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/)
+- Every commit must be signed off (DCO): use `git commit -s`.
+- Run `npm test` before committing.
+- Use Unix line endings (LF).
+- Documentation should describe released Pi-hole behaviour. Docs for unreleased features normally land alongside or after the feature is released, not before.
+- The correct project spelling is "Pi-hole" (capital P, lowercase h, hyphen). Use it consistently.
+
+## Common pitfalls
+
+- Adding a page without adding it to `nav` in `mkdocs.yml`, which fails the strict build.
+- Documenting behaviour from the `development` branches of other repos as if it were released.
+- Forgetting the DCO sign-off on commits.
+- Markdown that passes a casual preview but fails markdownlint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ The Pi-hole documentation, published at [docs.pi-hole.net](https://docs.pi-hole.
 ## Common pitfalls
 
 - Adding a page without adding it to `nav` in `mkdocs.yml`, which fails the strict build.
+- Editing `docs/ftldns/configfile.md` file. This file should not be changed. It is updated by an automated FTL PR, or every FTL release.
 - Documenting behaviour from the `development` branches of other repos as if it were released.
 - Forgetting the DCO sign-off on commits.
 - Markdown that passes a casual preview but fails markdownlint.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://docs.pi-hole.net/",
   "scripts": {
     "build": "mkdocs build --clean --strict",
-    "markdownlint": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**\"",
+    "markdownlint": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**\" \"!**/.git/**\"",
     "linkinator": "linkinator site --recurse --silent --skip \"^(?!http://localhost)\"",
     "pretest": "npm run build",
     "test": "npm run markdownlint && npm run linkinator",


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Adds an `AGENTS.md` file following the [agents.md](https://agents.md) standard: a predictable place for AI coding agents to find the repository layout, build/test commands and contribution requirements (DCO sign-off, branch targeting, code style) without them having to rediscover it every session. It is just standard markdown, and no tooling or workflow changes come with it.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
