### PR TITLE
Document PIHOLE_SELINUX environment variable

### DIFF
--- a/docs/main/update.md
+++ b/docs/main/update.md
@@ -7,6 +7,20 @@ Updating is as simple as running the following command:
 !!! warning "Always Read The Release Notes!"
     Ensure you read the release notes for all Pi-hole components. This will help you avoid common problems due to known issues with upgrading or newly required arguments. The release notes can be found in the respective repository for [Core](https://github.com/pi-hole/pi-hole/releases), [FTL](https://github.com/pi-hole/FTL/releases) and [Web](https://github.com/pi-hole/web/releases). This is especially recommended for major updates like `v5 -> v6`. Some updates are accompanied by a post on the [Pi-hole Blog](https://pi-hole.net/landing/blog/) mentioning notable changes.
 
+### SELinux
+
+If SELinux is detected in `Enforcing` mode, `pihole -up` will exit rather than continue, since Pi-hole does not provide an official SELinux policy and enforcing mode may cause issues during or after the update.
+
+!!! info
+    If you have already configured a custom SELinux policy that allows Pi-hole to function correctly, you can skip this check by setting the `PIHOLE_SELINUX` environment variable before running the update:
+
+    ```
+    export PIHOLE_SELINUX=true
+    pihole -up
+    ```
+
+    Setting this variable acknowledges that there may be issues with Pi-hole during or after the update while SELinux is enforcing.
+
 ### Updating Docker
 
 Please refer to the [Guide in the Docker Docs](../docker/upgrading/index.md)


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Documents the `PIHOLE_SELINUX` environment variable, which is currently undocumented anywhere on docs.pi-hole.net although it is present in the current `basic-install.sh`. Provides a reference for users who encounter the installer's SELinux Enforcing exit.

Fixes https://github.com/pi-hole/docs/issues/316

**How does this PR accomplish the above?:**

Added a new "SELinux" section to `docs/main/update.md`. It explains that `pihole -up` will exit if SELinux is detected in Enforcing mode, and documents how setting `PIHOLE_SELINUX=true` before running the update skips that check.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
